### PR TITLE
fix: bugs and cleanup

### DIFF
--- a/backend/common/utils.py
+++ b/backend/common/utils.py
@@ -1,35 +1,42 @@
 import os
+from functools import lru_cache
 from jinja2 import Environment, FileSystemLoader
+
+
+# Cache the template environment for the prompts directory
+@lru_cache(maxsize=1)
+def _get_prompts_env():
+    """Get cached Jinja2 environment for prompts directory."""
+    prompts_dir = os.path.join(os.path.dirname(__file__), "..", "prompts")
+    return FileSystemLoader(prompts_dir)
 
 
 def render_template(template_path: str, **context) -> str:
     """
     Render a Jinja2 template with provided context.
 
-    This function creates a new Jinja2 Environment for the template's directory on each call.
-    It supports any template path and is general-purpose for rendering templates from various locations.
-
     Args:
-        template_path (str): Full or relative path to the template file (e.g., 'prompts/recommender.jinja2').
+        template_path (str): Relative path to the template file within prompts directory.
         **context: Variables to pass to the template.
 
     Returns:
         str: Rendered template string.
-
-    Raises:
-        jinja2.TemplateNotFound: If the template file does not exist.
-        ValueError: If template_path is invalid.
     """
-    # Extract the directory containing the template
+    # For prompts directory templates, use cached environment
+    prompts_dir = os.path.join(os.path.dirname(__file__), "..", "prompts")
     template_dir = os.path.dirname(template_path)
 
-    # Create a loader and environment for this directory
-    loader = FileSystemLoader(template_dir)
-    env = Environment(loader=loader)
+    if (
+        template_path.startswith("prompts/")
+        or template_dir == prompts_dir
+        or not template_dir
+    ):
+        env = Environment(loader=_get_prompts_env())
+    else:
+        # Fallback for other template paths
+        loader = FileSystemLoader(template_dir)
+        env = Environment(loader=loader)
 
-    # Get the template name from the path and load it
     template_name = os.path.basename(template_path)
     template = env.get_template(template_name)
-
-    # Render the template with the provided context and return the result
     return template.render(**context)

--- a/backend/core/routes.py
+++ b/backend/core/routes.py
@@ -193,7 +193,7 @@ async def calculate_performance(request: PerformanceRequest):
                 current_price = float(regular_market_price)
             else:
                 # Last resort: fetch 1 day of data if price not in info
-                ohlc = await analyzer.data_service.get_ohlc(ticker, days=1)
+                ohlc = await analyzer.data_service.get_ohlc(ticker, period="1d")
                 if not ohlc.close:
                     raise ValueError(f"No data found for {ticker}")
                 current_price = float(ohlc.close[-1])

--- a/backend/features/watchlist/service.py
+++ b/backend/features/watchlist/service.py
@@ -21,7 +21,11 @@ class WatchlistService:
 
     def __init__(self):
         self.data_service = DataService()
-        self.watchlist_file = "data/watchlist.json"
+        # Use absolute path based on module location
+        module_dir = os.path.dirname(os.path.abspath(__file__))
+        self.watchlist_file = os.path.join(
+            module_dir, "..", "..", "data", "watchlist.json"
+        )
         self.watchlist = self._load_watchlist()
 
     def _load_watchlist(self) -> list[WatchlistEntry]:
@@ -67,15 +71,24 @@ class WatchlistService:
             for entry in self.watchlist
         ]
 
+        # Ensure directory exists
+        directory = os.path.dirname(self.watchlist_file)
+        if directory and not os.path.exists(directory):
+            os.makedirs(directory, exist_ok=True)
+
         try:
             with open(self.watchlist_file, "w") as f:
                 json.dump(watchlist_data, f, indent=2)
         except Exception as e:
-            print(f"Error saving watchlist: {e}")
+            raise RuntimeError(f"Failed to save watchlist: {e}") from e
 
     async def add_stock(self, request: WatchlistEntryRequest) -> WatchlistEntryResponse:
         """Add a stock to the watchlist"""
         ticker = request.ticker.upper()
+
+        # Check if ticker already exists in watchlist
+        if any(entry.ticker == ticker for entry in self.watchlist):
+            raise ValueError(f"{ticker} is already in watchlist")
 
         # Determine entry_date - default to today
         if request.entry_date:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7753,9 +7753,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,50 +6,9 @@ import PerformanceCalculatorPage from './pages/PerformanceCalculatorPage';
 import WatchlistPage from './pages/WatchlistPage';
 import { useState } from 'react';
 import './App.css';
+import { PERIODS, getDateRange } from './constants';
 
 type Tab = 'analysis' | 'performance' | 'watchlist';
-
-// Period options with date calculation
-const PERIODS = [
-  { value: '1mo', label: '1M', months: 1 },
-  { value: '3mo', label: '3M', months: 3 },
-  { value: '6mo', label: '6M', months: 6 },
-  { value: '1y', label: '1Y', years: 1 },
-  { value: '2y', label: '2Y', years: 2 },
-  { value: '5y', label: '5Y', years: 5 },
-  { value: '10y', label: '10Y', years: 10 },
-  { value: 'ytd', label: 'YTD', ytd: true },
-  { value: 'max', label: 'Max', max: true },
-];
-
-// Calculate start and end dates from period selection
-function getDateRange(
-  periodValue: string,
-): { startDate: string; endDate: string } | { period: string } {
-  const today = new Date();
-  const endDate = today.toISOString().split('T')[0]; // YYYY-MM-DD
-
-  const period = PERIODS.find((p) => p.value === periodValue);
-  if (!period) return { period: '5y' };
-
-  if (period.max) return { period: 'max' };
-  if (period.ytd) {
-    const startOfYear = new Date(today.getFullYear(), 0, 1).toISOString().split('T')[0];
-    return { startDate: startOfYear, endDate };
-  }
-  if (period.months) {
-    const startDate = new Date(today);
-    startDate.setMonth(startDate.getMonth() - period.months);
-    return { startDate: startDate.toISOString().split('T')[0], endDate };
-  }
-  if (period.years) {
-    const startDate = new Date(today);
-    startDate.setFullYear(startDate.getFullYear() - period.years);
-    return { startDate: startDate.toISOString().split('T')[0], endDate };
-  }
-
-  return { period: '5y' };
-}
 
 function PeriodSelector({
   value,

--- a/frontend/src/components/AnalysisResults/index.tsx
+++ b/frontend/src/components/AnalysisResults/index.tsx
@@ -3,6 +3,24 @@ import { MetricsCard } from '../MetricsCard';
 import { PriceChart } from '../PriceChart';
 import { MetricDefinition } from '../shared/MetricDefinition';
 import { AlertCircle } from 'lucide-react';
+import {
+  movingAverageDefinitions,
+  momentumDefinitions,
+  volatilityDefinitions,
+  profitabilityDefinitions,
+  valuationDefinitions,
+  financialStrengthDefinitions,
+  growthDefinitions,
+  liquidityValuationDefinitions,
+  earningsDefinitions,
+  marginsDefinitions,
+  financialHealthDefinitions,
+  marketDataDefinitions,
+  analystDefinitions,
+  shortInterestDefinitions,
+  performanceDefinitions,
+  ownershipDefinitions,
+} from '../../constants/metrics';
 
 interface AnalysisResultsProps {
   data: AnalysisData;
@@ -21,183 +39,6 @@ export function AnalysisResults({
   errorAI,
   onGenerateAI,
 }: AnalysisResultsProps) {
-  // Metric definitions for Technical Overview
-  const movingAverageDefinitions: Record<string, string> = {
-    'SMA 20':
-      'Simple Moving Average over the last 20 trading days (in price units, e.g., $150.00). Short-term trend indicator. Above 20 SMA = short-term bullish.',
-    'SMA 50':
-      'Simple Moving Average over the last 50 trading days (in price units). Medium-term trend indicator. Widely used by institutions.',
-    'SMA 100':
-      'Simple Moving Average over the last 100 trading days (in price units). Medium-long term trend indicator.',
-    'SMA 200':
-      'Simple Moving Average over the last 200 trading days (in price units). Long-term trend indicator. Price above 200 SMA = long-term bullish.',
-  };
-
-  const momentumDefinitions: Record<string, string> = {
-    'RSI 14':
-      'Relative Strength Index over 14 periods (scale 0-100). >70 = overbought (possible pullback), <30 = oversold (possible bounce). Below 50 = bearish, above 50 = bullish.',
-    MACD: 'Moving Average Convergence Divergence (in price units, e.g., +2.50 means short-term MA is $2.50 above long-term MA). Positive MACD = bullish momentum.',
-  };
-
-  const volatilityDefinitions: Record<string, string> = {
-    'ATR 14':
-      'Average True Range over 14 periods (in price units, e.g., $3.59 means the stock moves ~$3.59 per day on average). Higher ATR = more volatile stock.',
-    'Volatility 30D':
-      '30-day annualized volatility (shown as percentage, e.g., 17% means the stock has historically fluctuated 17% annually). Higher = more volatile.',
-    'Volatility 90D': '90-day annualized volatility (shown as percentage). Higher = more volatile.',
-  };
-
-  // Metric definitions for Fundamental Overview
-  const profitabilityDefinitions: Record<string, string> = {
-    ROE: 'Return on Equity (shown as %). Net income / Shareholder Equity. Measures efficiency at generating profits from shareholder money. >15% = good, >20% = excellent.',
-    'Profit Margin':
-      'Net profit / Revenue (shown as %). Percentage of revenue that becomes profit. Higher is better, but banking ~15-20% is solid, tech can be 20%+.',
-  };
-
-  const valuationDefinitions: Record<string, string> = {
-    'P/E Ratio (TTM)':
-      'Price / Earnings per share (ratio, e.g., 20x means you pay $20 for $1 of earnings). Lower may = undervalued, higher may = overvalued. Varies by industry.',
-    'Forward P/E':
-      'Price / Expected future EPS (ratio). Uses analyst estimates for next 12 months. Lower = potentially cheaper vs future earnings.',
-    'PEG Ratio':
-      'P/E / Growth Rate (ratio). <1 may indicate undervalued, 1-2 = fairly valued, >2 may indicate overvalued. Growth is annual %.',
-  };
-
-  const financialStrengthDefinitions: Record<string, string> = {
-    'Debt-to-Equity':
-      'Total Debt / Total Equity (ratio, e.g., 0.5 means 50 cents debt per $1 equity). <1 is generally conservative, >2 may indicate high leverage.',
-    'Dividend Yield':
-      "Annual Dividends / Stock Price (shown as %). Income return from dividends. 2-5% is typical. Higher isn't always better - check sustainability.",
-  };
-
-  const growthDefinitions: Record<string, string> = {
-    'Revenue Growth':
-      "Year-over-year % change in total revenue. >10% = strong growth. Varies by company stage (startups may grow faster but aren't profitable).",
-  };
-
-  const liquidityValuationDefinitions: Record<string, string> = {
-    'Enterprise Value':
-      'Market Cap + Debt - Cash (in billions, e.g., $50B). What it would cost to buy the whole company.',
-    'Price/Book':
-      'Stock price / Book value per share (ratio, e.g., 3x). <1 may = undervalued, >3 may = overvalued. Common for banks.',
-    'Price/Sales':
-      'Stock price / Revenue per share (ratio). Varies by industry; lower generally better. SaaS companies often trade at 10-20x.',
-    'EV/EBITDA':
-      'Enterprise Value / EBITDA (ratio). <10 generally considered good/cheap, >15 may be expensive.',
-    'Trailing PEG': 'P/E ratio / Expected earnings growth (ratio). <1 may indicate undervalued.',
-  };
-
-  const earningsDefinitions: Record<string, string> = {
-    'EPS (TTM)':
-      'Earnings Per Share Trailing Twelve Months (in dollars, e.g., $2.50). Actual reported earnings over the last 12 months.',
-    'Forward EPS':
-      'Expected EPS over next 12 months (in dollars, e.g., $5.00). Analyst consensus estimates.',
-    'Book Value':
-      'Total assets - Total liabilities per share (in dollars). Represents intrinsic value.',
-    'Book/Share': 'Book value per share (in dollars, same as above).',
-    'Earnings Growth': 'Year-over-year % change in earnings. Positive = growing profits.',
-    'Quarterly Growth': 'Quarter-over-quarter % change in earnings. Shows momentum.',
-  };
-
-  const marginsDefinitions: Record<string, string> = {
-    'Return on Assets':
-      'Net income / Total assets (shown as %). Efficiency at using assets. >5% = good.',
-    'Return on Investment':
-      'Net income / Total investments (shown as %). Similar to ROE but for all capital.',
-    'Gross Margins':
-      '(Revenue - COGS) / Revenue (shown as %). Profitability before operating costs. >40% = strong, <20% = low margin industry.',
-    'Operating Margins':
-      'Operating income / Revenue (shown as %). Profitability from core ops. 15-20% = healthy.',
-  };
-
-  const financialHealthDefinitions: Record<string, string> = {
-    EBITDA:
-      'Earnings Before Interest, Taxes, Depreciation & Amortization (in billions). Shows operating cash flow. Higher = more profitable core business.',
-    'Total Cash': 'Total cash on hand (in billions). Buffer for emergencies or acquisitions.',
-    'Total Debt': 'Total debt outstanding (in billions). Higher debt = more financial risk.',
-    'Current Ratio':
-      'Current Assets / Current Liabilities. >1.5 = healthy liquidity, <1 = may struggle to pay bills.',
-    'Quick Ratio':
-      '(Current Assets - Inventory) / Current Liabilities. Strict liquidity measure without relying on inventory.',
-    'Payout Ratio':
-      'Dividends paid / Earnings (shown as %). High (>80%) may be unsustainable. Low (<30%) suggests room to increase dividends.',
-    'Cash/Share':
-      'Total cash divided by shares outstanding (in dollars). Cash per share indicates financial flexibility.',
-    'Operating Cash Flow':
-      'Cash generated from core business operations (in billions). Includes all operating expenses but NOT capital expenditures.',
-    'Free Cash Flow':
-      'Operating Cash Flow minus Capital Expenditures (in billions). What remains after investing in assets. Higher = more value generated for shareholders.',
-  };
-
-  const marketDataDefinitions: Record<string, string> = {
-    'Previous Close':
-      "Most recent closing price before today (in dollars). Yesterday's final market price.",
-    'Day High': 'Highest price traded during the current trading session (in dollars).',
-    'Day Low': 'Lowest price traded during the current trading session (in dollars).',
-    Bid: 'Highest price a buyer is willing to pay for shares right now (in dollars).',
-    Ask: 'Lowest price a seller is willing to accept for shares right now (in dollars).',
-    Volume:
-      'Total shares traded today (e.g., 5.2M = 5.2 million shares). Higher volume = more liquid.',
-    'Avg Volume': 'Average daily volume over recent sessions. Shows typical trading activity.',
-    '52W High': 'Highest price in the past 52 weeks (in dollars).',
-    '52W Low': 'Lowest price in the past 52 weeks (in dollars).',
-  };
-
-  const analystDefinitions: Record<string, string> = {
-    'Analyst Opinions':
-      'Number of Wall Street analysts covering this stock. More opinions = more coverage.',
-    Recommendation: 'Wall Street consensus: Strong Buy, Buy, Hold, Underperform, Sell.',
-    'Rec. Mean':
-      'Average analyst rating (1=Strong Buy, 2=Buy, 3=Hold, 4=Underperform, 5=Sell). Lower = more bullish.',
-    'Avg Analyst Rating': 'Human-readable analyst consensus (e.g., "1.9 - Buy").',
-    'Target High':
-      'Highest price target from analysts (in dollars). Upside potential if targets are met.',
-    'Target Low':
-      'Lowest price target from analysts (in dollars). Downside risk if targets are missed.',
-    '50D Avg':
-      '50-day moving average price. Short-term trend line. Price above = short-term bullish.',
-    '200D Avg':
-      '200-day moving average price. Long-term trend line. Price above = long-term bullish.',
-  };
-
-  const shortInterestDefinitions: Record<string, string> = {
-    'Shares Short':
-      'Number of shares currently sold short (e.g., 229M = 229 million shares). High short interest = bearish bets against stock.',
-    'Short Ratio':
-      'Days to cover short positions (shares short / avg daily volume). Higher = harder to close shorts, potential squeeze.',
-    'Short % of Float':
-      'Percentage of float shares that are shorted. High % = significant bearish sentiment, risk of short squeeze.',
-    'Float Shares':
-      'Shares available for public trading (in millions). Excludes insider/restricted shares.',
-    'Trailing Ann. Div. Rate':
-      'Sum of dividends paid over the past 12 months (in $/share). Actual dividends received.',
-    'Trailing Ann. Div. Yield':
-      'Trailing 12-month dividends / current price (in %). Actual dividend return received (NVDA: 0.04/177.39 = 0.023%).',
-    '5Y Avg Div. Yield':
-      '5-year average dividend yield (in %). Useful for comparing current yield to historical yield.',
-  };
-
-  const performanceDefinitions: Record<string, string> = {
-    '52W Change': 'Percentage price change over the past 52 weeks. Positive = price appreciation.',
-    'S&P 52W Change':
-      'S&P 500 index percentage change over the same 52-week period. Compare stock performance vs market.',
-    'All-Time High':
-      'Highest price this stock has ever traded at (historical). Current price is X% below ATH.',
-    'All-Time Low':
-      'Lowest price this stock has ever traded at (historical). Current price is X% above ATL.',
-  };
-
-  const ownershipDefinitions: Record<string, string> = {
-    'Shares Outstanding':
-      'Total shares currently in existence (in millions). Used to calculate market cap.',
-    'Revenue/Share':
-      'Total revenue / shares outstanding (in dollars). Higher = more efficient at generating revenue.',
-    'Insider Ownership':
-      'Percentage of shares held by company insiders (executives, directors). High = insiders confident.',
-    'Institutional Ownership':
-      'Percentage of shares held by funds/pension plans. High = professional confidence.',
-  };
-
   return (
     <div className="space-y-8">
       {/* Company Header */}

--- a/frontend/src/components/shared/ErrorAlert.tsx
+++ b/frontend/src/components/shared/ErrorAlert.tsx
@@ -1,0 +1,15 @@
+import { AlertCircle } from 'lucide-react';
+
+interface ErrorAlertProps {
+  message: string;
+  className?: string;
+}
+
+export function ErrorAlert({ message, className = '' }: ErrorAlertProps) {
+  return (
+    <div className={`mt-4 p-4 bg-red-50 border border-red-200 rounded-xl flex gap-3 ${className}`}>
+      <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+      <p className="text-red-800 text-sm">{message}</p>
+    </div>
+  );
+}

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -15,3 +15,45 @@ export const PERIODS = [
   { value: 'ytd', label: 'YTD' },
   { value: 'max', label: 'Max' },
 ];
+
+// Extended PERIODS with date calculation properties
+const PERIODS_WITH_CALC = [
+  { value: '1mo', label: '1M', months: 1 },
+  { value: '3mo', label: '3M', months: 3 },
+  { value: '6mo', label: '6M', months: 6 },
+  { value: '1y', label: '1Y', years: 1 },
+  { value: '2y', label: '2Y', years: 2 },
+  { value: '5y', label: '5Y', years: 5 },
+  { value: '10y', label: '10Y', years: 10 },
+  { value: 'ytd', label: 'YTD', ytd: true },
+  { value: 'max', label: 'Max', max: true },
+];
+
+// Calculate start and end dates from period selection
+export const getDateRange = (
+  periodValue: string,
+): { startDate: string; endDate: string } | { period: string } => {
+  const today = new Date();
+  const endDate = today.toISOString().split('T')[0];
+
+  const period = PERIODS_WITH_CALC.find((p) => p.value === periodValue);
+  if (!period) return { period: '5y' };
+
+  if (period.max) return { period: 'max' };
+  if (period.ytd) {
+    const startOfYear = new Date(today.getFullYear(), 0, 1).toISOString().split('T')[0];
+    return { startDate: startOfYear, endDate };
+  }
+  if (period.months) {
+    const startDate = new Date(today);
+    startDate.setMonth(startDate.getMonth() - period.months);
+    return { startDate: startDate.toISOString().split('T')[0], endDate };
+  }
+  if (period.years) {
+    const startDate = new Date(today);
+    startDate.setFullYear(startDate.getFullYear() - period.years);
+    return { startDate: startDate.toISOString().split('T')[0], endDate };
+  }
+
+  return { period: '5y' };
+};

--- a/frontend/src/constants/metrics.ts
+++ b/frontend/src/constants/metrics.ts
@@ -1,0 +1,174 @@
+export const movingAverageDefinitions: Record<string, string> = {
+  'SMA 20':
+    'Simple Moving Average over the last 20 trading days (in price units, e.g., $150.00). Short-term trend indicator. Above 20 SMA = short-term bullish.',
+  'SMA 50':
+    'Simple Moving Average over the last 50 trading days (in price units). Medium-term trend indicator. Widely used by institutions.',
+  'SMA 100':
+    'Simple Moving Average over the last 100 trading days (in price units). Medium-long term trend indicator.',
+  'SMA 200':
+    'Simple Moving Average over the last 200 trading days (in price units). Long-term trend indicator. Price above 200 SMA = long-term bullish.',
+};
+
+export const momentumDefinitions: Record<string, string> = {
+  'RSI 14':
+    'Relative Strength Index over 14 periods (scale 0-100). >70 = overbought (possible pullback), <30 = oversold (possible bounce). Below 50 = bearish, above 50 = bullish.',
+  MACD: 'Moving Average Convergence Divergence (in price units, e.g., +2.50 means short-term MA is $2.50 above long-term MA). Positive MACD = bullish momentum.',
+};
+
+export const volatilityDefinitions: Record<string, string> = {
+  'ATR 14':
+    'Average True Range over 14 periods (in price units, e.g., $3.59 means the stock moves ~$3.59 per day on average). Higher ATR = more volatile stock.',
+  'Volatility 30D':
+    '30-day annualized volatility (shown as percentage, e.g., 17% means the stock has historically fluctuated 17% annually). Higher = more volatile.',
+  'Volatility 90D': '90-day annualized volatility (shown as percentage). Higher = more volatile.',
+};
+
+export const profitabilityDefinitions: Record<string, string> = {
+  ROE: 'Return on Equity (shown as %). Net income / Shareholder Equity. Measures efficiency at generating profits from shareholder money. >15% = good, >20% = excellent.',
+  'Profit Margin':
+    'Net profit / Revenue (shown as %). Percentage of revenue that becomes profit. Higher is better, but banking ~15-20% is solid, tech can be 20%+.',
+};
+
+export const valuationDefinitions: Record<string, string> = {
+  'P/E Ratio (TTM)':
+    'Price / Earnings per share (ratio, e.g., 20x means you pay $20 for $1 of earnings). Lower may = undervalued, higher may = overvalued. Varies by industry.',
+  'Forward P/E':
+    'Price / Expected future EPS (ratio). Uses analyst estimates for next 12 months. Lower = potentially cheaper vs future earnings.',
+  'PEG Ratio':
+    'P/E / Growth Rate (ratio). <1 may indicate undervalued, 1-2 = fairly valued, >2 may indicate overvalued. Growth is annual %.',
+};
+
+export const financialStrengthDefinitions: Record<string, string> = {
+  'Debt-to-Equity':
+    'Total Debt / Total Equity (ratio, e.g., 0.5 means 50 cents debt per $1 equity). <1 is generally conservative, >2 may indicate high leverage.',
+  'Dividend Yield':
+    "Annual Dividends / Stock Price (shown as %). Income return from dividends. 2-5% is typical. Higher isn't always better - check sustainability.",
+};
+
+export const growthDefinitions: Record<string, string> = {
+  'Revenue Growth':
+    "Year-over-year % change in total revenue. >10% = strong growth. Varies by company stage (startups may grow faster but aren't profitable).",
+};
+
+export const liquidityValuationDefinitions: Record<string, string> = {
+  'Enterprise Value':
+    'Market Cap + Debt - Cash (in billions, e.g., $50B). What it would cost to buy the whole company.',
+  'Price/Book':
+    'Stock price / Book value per share (ratio, e.g., 3x). <1 may = undervalued, >3 may = overvalued. Common for banks.',
+  'Price/Sales':
+    'Stock price / Revenue per share (ratio). Varies by industry; lower generally better. SaaS companies often trade at 10-20x.',
+  'EV/EBITDA':
+    'Enterprise Value / EBITDA (ratio). <10 generally considered good/cheap, >15 may be expensive.',
+  'Trailing PEG': 'P/E ratio / Expected earnings growth (ratio). <1 may indicate undervalued.',
+};
+
+export const earningsDefinitions: Record<string, string> = {
+  'EPS (TTM)':
+    'Earnings Per Share Trailing Twelve Months (in dollars, e.g., $2.50). Actual reported earnings over the last 12 months.',
+  'Forward EPS':
+    'Expected EPS over next 12 months (in dollars, e.g., $5.00). Analyst consensus estimates.',
+  'Book Value':
+    'Total assets - Total liabilities per share (in dollars). Represents intrinsic value.',
+  'Book/Share': 'Book value per share (in dollars, same as above).',
+  'Earnings Growth': 'Year-over-year % change in earnings. Positive = growing profits.',
+  'Quarterly Growth': 'Quarter-over-quarter % change in earnings. Shows momentum.',
+};
+
+export const marginsDefinitions: Record<string, string> = {
+  'Return on Assets':
+    'Net income / Total assets (shown as %). Efficiency at using assets. >5% = good.',
+  'Return on Investment':
+    'Net income / Total investments (shown as %). Similar to ROE but for all capital.',
+  'Gross Margins':
+    '(Revenue - COGS) / Revenue (shown as %). Profitability before operating costs. >40% = strong, <20% = low margin industry.',
+  'Operating Margins':
+    'Operating income / Revenue (shown as %). Profitability from core ops. 15-20% = healthy.',
+};
+
+export const financialHealthDefinitions: Record<string, string> = {
+  EBITDA:
+    'Earnings Before Interest, Taxes, Depreciation & Amortization (in billions). Shows operating cash flow. Higher = more profitable core business.',
+  'Total Cash': 'Total cash on hand (in billions). Buffer for emergencies or acquisitions.',
+  'Total Debt': 'Total debt outstanding (in billions). Higher debt = more financial risk.',
+  'Current Ratio':
+    'Current Assets / Current Liabilities. >1.5 = healthy liquidity, <1 = may struggle to pay bills.',
+  'Quick Ratio':
+    '(Current Assets - Inventory) / Current Liabilities. Strict liquidity measure without relying on inventory.',
+  'Payout Ratio':
+    'Dividends paid / Earnings (shown as %). High (>80%) may be unsustainable. Low (<30%) suggests room to increase dividends.',
+  'Cash/Share':
+    'Total cash divided by shares outstanding (in dollars). Cash per share indicates financial flexibility.',
+  'Operating Cash Flow':
+    'Cash generated from core business operations (in billions). Includes all operating expenses but NOT capital expenditures.',
+  'Free Cash Flow':
+    'Operating Cash Flow minus Capital Expenditures (in billions). What remains after investing in assets. Higher = more value generated for shareholders.',
+};
+
+export const marketDataDefinitions: Record<string, string> = {
+  'Previous Close':
+    "Most recent closing price before today (in dollars). Yesterday's final market price.",
+  'Day High': 'Highest price traded during the current trading session (in dollars).',
+  'Day Low': 'Lowest price traded during the current trading session (in dollars).',
+  Bid: 'Highest price a buyer is willing to pay for shares right now (in dollars).',
+  Ask: 'Lowest price a seller is willing to accept for shares right now (in dollars).',
+  Volume:
+    'Total shares traded today (e.g., 5.2M = 5.2 million shares). Higher volume = more liquid.',
+  'Avg Volume': 'Average daily volume over recent sessions. Shows typical trading activity.',
+  '52W High': 'Highest price in the past 52 weeks (in dollars).',
+  '52W Low': 'Lowest price in the past 52 weeks (in dollars).',
+};
+
+export const analystDefinitions: Record<string, string> = {
+  'Analyst Opinions':
+    'Number of Wall Street analysts covering this stock. More opinions = more coverage.',
+  Recommendation: 'Wall Street consensus: Strong Buy, Buy, Hold, Underperform, Sell.',
+  'Rec. Mean':
+    'Average analyst rating (1=Strong Buy, 2=Buy, 3=Hold, 4=Underperform, 5=Sell). Lower = more bullish.',
+  'Avg Analyst Rating': 'Human-readable analyst consensus (e.g., "1.9 - Buy").',
+  'Target High':
+    'Highest price target from analysts (in dollars). Upside potential if targets are met.',
+  'Target Low':
+    'Lowest price target from analysts (in dollars). Downside risk if targets are missed.',
+  '50D Avg':
+    '50-day moving average price. Short-term trend line. Price above = short-term bullish.',
+  '200D Avg':
+    '200-day moving average price. Long-term trend line. Price above = long-term bullish.',
+};
+
+export const shortInterestDefinitions: Record<string, string> = {
+  'Shares Short':
+    'Number of shares currently sold short (e.g., 229M = 229 million shares). High short interest = bearish bets against stock.',
+  'Short Ratio':
+    'Days to cover short positions (shares short / avg daily volume). Higher = harder to close shorts, potential squeeze.',
+  'Short % of Float':
+    'Percentage of float shares that are shorted. High % = significant bearish sentiment, risk of short squeeze.',
+  'Float Shares':
+    'Shares available for public trading (in millions). Excludes insider/restricted shares.',
+  'Trailing Ann. Div. Rate':
+    'Sum of dividends paid over the past 12 months (in $/share). Actual dividends received.',
+  'Trailing Ann. Div. Yield':
+    'Trailing 12-month dividends / current price (in %). Actual dividend return received (NVDA: 0.04/177.39 = 0.023%).',
+  '5Y Avg Div. Yield':
+    '5-year average dividend yield (in %). Useful for comparing current yield to historical yield.',
+};
+
+export const performanceDefinitions: Record<string, string> = {
+  '52W Change': 'Percentage price change over the past 52 weeks. Positive = price appreciation.',
+  'S&P 52W Change':
+    'S&P 500 index percentage change over the same 52-week period. Compare stock performance vs market.',
+  'All-Time High':
+    'Highest price this stock has ever traded at (historical). Current price is X% below ATH.',
+  'All-Time Low':
+    'Lowest price this stock has ever traded at (historical). Current price is X% above ATL.',
+};
+
+export const ownershipDefinitions: Record<string, string> = {
+  'Shares Outstanding':
+    'Total shares currently in existence (in millions). Used to calculate market cap.',
+  'Revenue/Share':
+    'Total revenue / shares outstanding (in dollars). Higher = more efficient at generating revenue.',
+  'Insider Ownership':
+    'Percentage of shares held by company insiders (executives, directors). High = insiders confident.',
+  'Institutional Ownership':
+    'Percentage of shares held by funds/pension plans. High = professional confidence.',
+};

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -1,0 +1,27 @@
+export const getGainLossColor = (value: number): string =>
+  value >= 0 ? 'text-green-600' : 'text-red-600';
+
+export const getGainLossBgColor = (value: number): string =>
+  value >= 0 ? 'bg-green-50' : 'bg-red-50';
+
+export const formatCurrency = (value: number, decimals = 2): string =>
+  `$${value.toFixed(decimals)}`;
+
+export const formatPercent = (value: number, decimals = 2): string =>
+  `${value >= 0 ? '+' : ''}${value.toFixed(decimals)}%`;
+
+export const formatNumber = (value: number, decimals = 2): string => value.toFixed(decimals);
+
+export const formatDate = (date: Date | string | number): string => {
+  const d = new Date(date);
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+export const formatTimestamp = (timestamp: number): string => {
+  if (!timestamp || timestamp === 0) return 'N/A';
+  return formatDate(new Date(timestamp * 1000));
+};


### PR DESCRIPTION
# Description
Frontend:

- Deduplicated PERIODS constant (moved getDateRange to constants/index.ts)
- Created [utils/formatting.ts](vscode-webview://11b0l876daaf7i0kfl5e02proeps13u00nn31e7h6e986cb2drii/frontend/src/utils/formatting.ts) with color/text helpers
- Extracted ~175 lines of metric definitions to [constants/metrics.ts](vscode-webview://11b0l876daaf7i0kfl5e02proeps13u00nn31e7h6e986cb2drii/frontend/src/constants/metrics.ts)
= Added [ErrorAlert.tsx](vscode-webview://11b0l876daaf7i0kfl5e02proeps13u00nn31e7h6e986cb2drii/frontend/src/components/shared/ErrorAlert.tsx) shared component

Backend:

- Fixed watchlist duplicate bug (raises ValueError if ticker exists)
- Fixed relative path issue (uses absolute path to module)
- Added @lru_cache for Jinja2 template environment
- Fixed routes.py calling get_ohlc(ticker, days=1) → get_ohlc(ticker, period="1d")

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [x] refactor
- [ ] chore

## Images
<!-- Any images as evidence -->

## Checklist

- [x] Code works as expected
- [x] No breaking changes (or clearly documented)
- [x] Code is clean and readable
