### PR TITLE
feat: comprehensive enhancements - rate limits, UI, period filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,22 @@
 
 ## Overview
 
-A project to learn about building a stock analysis application.
+A comprehensive stock analysis application that helps users make informed investment decisions by providing detailed financial metrics, technical analysis, AI-powered insights, and portfolio tracking tools.
 
-The goals of this project are to:
+The application provides:
 
-1. Build a website that enables users to input a stock ticker
-2. When the user presses "analyze", an AI agent will recommend insights about the stock
+1. **Stock Analysis** - Enter any stock ticker to get comprehensive analysis including:
+   - Technical indicators (RSI, MACD, Bollinger Bands, Moving Averages, etc.)
+   - Fundamental metrics (P/E ratio, ROE, margins, dividend data, etc.)
+   - Advanced statistics (Sharpe ratio, Sortino ratio, max drawdown, etc.)
+   - Seasonal patterns and trailing returns
+   - Real-time news integration
+
+2. **AI-Powered Insights** - Get AI-generated bull/bear case analysis, risk factors, and recommendations based on comprehensive financial data
+
+3. **Performance Calculator** - Track potential gains/losses by entering purchase price, quantity, and date
+
+4. **Watchlist** - Monitor stocks you're interested in with entry prices and notes
 
 ## Tech Stack
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -37,7 +37,11 @@ def _is_valid_ticker(ticker: str) -> bool:
     return 1 < len(ticker) < 10 and ticker.replace(".", "").isalnum()
 
 
-@router.post("/analyze")
+@router.post(
+    "/analyze",
+    summary="Analyze a stock",
+    description="Get comprehensive stock analysis including technical indicators, fundamental metrics, and advanced statistics.",
+)
 async def analyze_stock(request: dict, analyzer: StockAnalyzer = Depends(get_analyzer)):
     """Comprehensive stock analysis endpoint."""
     ticker = request.get("ticker", "").upper()
@@ -65,7 +69,11 @@ async def analyze_stock(request: dict, analyzer: StockAnalyzer = Depends(get_ana
         raise HTTPException(status_code=500, detail="Analysis failed")
 
 
-@router.post("/analyze/ai")
+@router.post(
+    "/analyze/ai",
+    summary="Generate AI analysis",
+    description="Generate AI-powered analysis with bull/bear case, risk factors, and recommendations.",
+)
 async def generate_ai_analysis(
     request: AIAnalysisRequest,
     analyzer: StockAnalyzer = Depends(get_analyzer),
@@ -95,7 +103,11 @@ async def generate_ai_analysis(
         raise HTTPException(status_code=500, detail="AI analysis failed")
 
 
-@router.post("/chart-data")
+@router.post(
+    "/chart-data",
+    summary="Get chart data",
+    description="Lightweight endpoint to fetch only price chart data (OHLC) with moving averages.",
+)
 async def get_chart_data(request: dict, data_source: Any = Depends(get_data_source)):
     """Lightweight endpoint to fetch only chart data (OHLC)."""
     ticker = request.get("ticker", "").upper()
@@ -148,7 +160,11 @@ async def get_chart_data(request: dict, data_source: Any = Depends(get_data_sour
         raise HTTPException(status_code=500, detail="Failed to fetch chart data")
 
 
-@router.post("/performance")
+@router.post(
+    "/performance",
+    summary="Calculate performance",
+    description="Calculate stock performance from purchase date to current date.",
+)
 async def calculate_performance(
     request: dict, data_source: Any = Depends(get_data_source)
 ):
@@ -190,7 +206,11 @@ async def calculate_performance(
         raise HTTPException(status_code=500, detail="Performance calculation failed")
 
 
-@router.post("/watchlist")
+@router.post(
+    "/watchlist",
+    summary="Add to watchlist",
+    description="Add a stock to the watchlist with entry price and notes.",
+)
 async def add_to_watchlist(request: dict, data_source: Any = Depends(get_data_source)):
     """Add a stock to the watchlist."""
     from datetime import datetime
@@ -228,7 +248,11 @@ async def add_to_watchlist(request: dict, data_source: Any = Depends(get_data_so
         raise HTTPException(status_code=500, detail="Failed to add stock to watchlist")
 
 
-@router.delete("/watchlist/{id}")
+@router.delete(
+    "/watchlist/{id}",
+    summary="Remove from watchlist",
+    description="Remove a stock from the watchlist.",
+)
 async def delete_from_watchlist(id: str):
     """Delete a stock from the watchlist."""
     try:
@@ -245,7 +269,11 @@ async def delete_from_watchlist(id: str):
         )
 
 
-@router.get("/watchlist")
+@router.get(
+    "/watchlist",
+    summary="Get watchlist",
+    description="Retrieve all watchlist entries, optionally filtered by user.",
+)
 async def get_watchlist(
     added_by: str | None = None, data_source: Any = Depends(get_data_source)
 ):
@@ -257,7 +285,11 @@ async def get_watchlist(
         raise HTTPException(status_code=500, detail="Failed to retrieve watchlist")
 
 
-@router.get("/market/summary")
+@router.get(
+    "/market/summary",
+    summary="Market summary",
+    description="Get market summary with major indices prices and daily changes.",
+)
 async def get_market_summary():
     """Get market summary with major indices."""
     try:

--- a/backend/domain/models.py
+++ b/backend/domain/models.py
@@ -251,10 +251,27 @@ class SeasonalAnalysis:
 
 
 @dataclass(frozen=True)
+class PatternMetrics:
+    head_and_shoulders: bool = False
+    inverted_head_and_shoulders: bool = False
+    double_top: bool = False
+    double_bottom: bool = False
+    triangle_pattern: str | None = None
+    flag_pattern: bool = False
+    cup_and_handle: bool = False
+    adx: float | None = None
+    gap_up_detected: bool = False
+    gap_down_detected: bool = False
+    support_break: bool = False
+    resistance_break: bool = False
+
+
+@dataclass(frozen=True)
 class AdvancedMetrics:
     statistical: StatisticalMetrics
     technical: TechnicalPerformance
     seasonal: SeasonalAnalysis | None = None
+    patterns: PatternMetrics | None = None
     disclaimer: str = (
         "Advanced metrics are statistical estimates for educational purposes only."
     )

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,8 +8,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from api.routes import router
 
 app = FastAPI(
-    title="Stock Deep Dive Assistant API",
-    description="Stock analysis API",
+    title="Stock Deep Dive API",
+    description="Comprehensive stock analysis API with technical indicators, fundamental metrics, and AI-powered insights.",
+    version="1.0.0",
+    docs_url="/docs",
+    redoc_url="/redoc",
 )
 
 app.add_middleware(
@@ -24,9 +27,3 @@ app.add_middleware(
 )
 
 app.include_router(router, prefix="/api")
-
-
-@app.get("/health")
-async def health_check():
-    """Health check endpoint for Render."""
-    return {"status": "ok"}

--- a/backend/services/advanced.py
+++ b/backend/services/advanced.py
@@ -8,6 +8,7 @@ from domain.models import (
     StatisticalMetrics,
     TechnicalPerformance,
     SeasonalAnalysis,
+    PatternMetrics,
 )
 
 
@@ -27,9 +28,13 @@ def calculate_all(df: pd.DataFrame, risk_free_rate: float = 0.02) -> AdvancedMet
     statistical = _calculate_statistical(close, daily_returns, risk_free_rate)
     technical = _calculate_technical(close, high, low, volume, df.index)
     seasonal = _calculate_seasonal(close, df.index)
+    patterns = _detect_patterns(close, high, low, volume)
 
     return AdvancedMetrics(
-        statistical=statistical, technical=technical, seasonal=seasonal
+        statistical=statistical,
+        technical=technical,
+        seasonal=seasonal,
+        patterns=patterns,
     )
 
 
@@ -38,6 +43,49 @@ def _calculate_statistical(
 ) -> StatisticalMetrics:
     total_return = (close.iloc[-1] / close.iloc[0]) - 1
     years = len(close) / 252
+
+    # Handle edge cases: require at least 30 trading days (~6 weeks) for meaningful annualized metrics
+    if years < 0.12:  # ~30 trading days
+        return StatisticalMetrics(
+            total_return=float(total_return),
+            annualized_return=None,
+            annualized_volatility=None,
+            sharpe_ratio=None,
+            sortino_ratio=None,
+            max_drawdown=None,
+            cagr=None,
+            calmar_ratio=None,
+            var_95=None,
+            skewness=None,
+            kurtosis=None,
+            ulcer_index=None,
+            recovery_days=None,
+            beta=None,
+            alpha=None,
+            r_squared=None,
+        )
+
+    # Guard against invalid values in base
+    if close.iloc[0] <= 0:
+        return StatisticalMetrics(
+            total_return=float(total_return),
+            annualized_return=None,
+            annualized_volatility=None,
+            sharpe_ratio=None,
+            sortino_ratio=None,
+            max_drawdown=None,
+            cagr=None,
+            calmar_ratio=None,
+            var_95=None,
+            skewness=None,
+            kurtosis=None,
+            ulcer_index=None,
+            recovery_days=None,
+            beta=None,
+            alpha=None,
+            r_squared=None,
+        )
+
     annualized_return = (1 + total_return) ** (1 / years) - 1 if years > 0 else 0
     annualized_volatility = daily_returns.std() * np.sqrt(252)
     excess_return = annualized_return - risk_free_rate
@@ -309,3 +357,332 @@ def _calculate_weekday_effect(
     returns_dict = {days[int(d)]: float(r) for d, r in weekday_avg.items()}
     win_rate_dict = {days[int(d)]: float(w) for d, w in weekday_win.items()}
     return returns_dict, win_rate_dict
+
+
+def _detect_patterns(
+    close: pd.Series, high: pd.Series, low: pd.Series, volume: pd.Series
+) -> PatternMetrics:
+    """Detect common chart patterns."""
+    patterns = PatternMetrics()
+
+    if len(close) < 60:
+        return patterns
+
+    try:
+        # Calculate ADX (Average Directional Index) for trend strength
+        adx_val = _calculate_adx(high, low, close, window=14)
+        patterns.adx = adx_val
+
+        # Detect gaps
+        gaps = _detect_gaps(close)
+        patterns.gap_up_detected = gaps["gap_up"]
+        patterns.gap_down_detected = gaps["gap_down"]
+
+        # Detect support/resistance breaks
+        patterns.support_break = _detect_support_break(close, low)
+        patterns.resistance_break = _detect_resistance_break(close, high)
+
+        # Detect double top and bottom
+        patterns.double_top = _detect_double_top(high)
+        patterns.double_bottom = _detect_double_bottom(low)
+
+        # Detect head and shoulders
+        patterns.head_and_shoulders = _detect_head_and_shoulders(close, high, low)
+        patterns.inverted_head_and_shoulders = _detect_inverted_head_and_shoulders(
+            close, high, low
+        )
+
+        # Detect triangle patterns
+        patterns.triangle_pattern = _detect_triangle(high, low, close)
+
+        # Detect flag pattern
+        patterns.flag_pattern = _detect_flag(close, volume)
+
+        # Detect cup and handle
+        patterns.cup_and_handle = _detect_cup_and_handle(close)
+
+    except Exception:
+        pass
+
+    return patterns
+
+
+def _calculate_adx(
+    high: pd.Series, low: pd.Series, close: pd.Series, window: int = 14
+) -> float | None:
+    """Calculate ADX (Average Directional Index) for trend strength."""
+    try:
+        from ta.trend import ADXIndicator
+
+        adx = ADXIndicator(high, low, close, window=window)
+        return float(adx.adx().iloc[-1]) if len(close) >= window else None
+    except Exception:
+        return None
+
+
+def _detect_gaps(close: pd.Series) -> dict[str, bool]:
+    """Detect significant price gaps."""
+    result = {"gap_up": False, "gap_down": False}
+    if len(close) < 2:
+        return result
+
+    pct_change = close.pct_change().dropna()
+    if len(pct_change) < 1:
+        return result
+
+    last_change = pct_change.iloc[-1]
+    # Gap up: >2% up from previous close
+    if last_change > 0.02:
+        result["gap_up"] = True
+    # Gap down: >2% down from previous close
+    if last_change < -0.02:
+        result["gap_down"] = True
+
+    return result
+
+
+def _detect_support_break(close: pd.Series, low: pd.Series) -> bool:
+    """Detect support level break."""
+    if len(close) < 20:
+        return False
+
+    # Find recent support level (lowest point in last 20 periods)
+    support_level = low.tail(20).min()
+    current_price = close.iloc[-1]
+
+    # Support break: price closes below support
+    return current_price < support_level
+
+
+def _detect_resistance_break(close: pd.Series, high: pd.Series) -> bool:
+    """Detect resistance level break."""
+    if len(close) < 20:
+        return False
+
+    # Find recent resistance level (highest point in last 20 periods)
+    resistance_level = high.tail(20).max()
+    current_price = close.iloc[-1]
+
+    # Resistance break: price closes above resistance
+    return current_price > resistance_level
+
+
+def _detect_double_top(high: pd.Series, threshold: float = 0.02) -> bool:
+    """Detect double top pattern (two peaks at similar levels)."""
+    if len(high) < 60:
+        return False
+
+    recent_highs = high.tail(60)
+    peaks = _find_peaks(recent_highs, min_distance=20)
+
+    if len(peaks) < 2:
+        return False
+
+    # Get the two most recent peaks
+    peak1_val = recent_highs.iloc[peaks[-2]] if len(peaks) >= 2 else 0
+    peak2_val = recent_highs.iloc[peaks[-1]]
+
+    # Check if they're at similar levels (within threshold %)
+    if peak1_val == 0:
+        return False
+    return abs(peak1_val - peak2_val) / peak1_val < threshold
+
+
+def _detect_double_bottom(low: pd.Series, threshold: float = 0.02) -> bool:
+    """Detect double bottom pattern (two troughs at similar levels)."""
+    if len(low) < 60:
+        return False
+
+    recent_lows = low.tail(60)
+    troughs = _find_troughs(recent_lows, min_distance=20)
+
+    if len(troughs) < 2:
+        return False
+
+    # Get the two most recent troughs
+    trough1_val = recent_lows.iloc[troughs[-2]] if len(troughs) >= 2 else 0
+    trough2_val = recent_lows.iloc[troughs[-1]]
+
+    # Check if they're at similar levels (within threshold %)
+    if trough1_val == 0:
+        return False
+    return abs(trough1_val - trough2_val) / trough1_val < threshold
+
+
+def _find_peaks(series: pd.Series, min_distance: int = 10) -> list[int]:
+    """Find peak indices in a series."""
+    peaks = []
+    for i in range(min_distance, len(series) - min_distance):
+        if (
+            series.iloc[i] >= series.iloc[i - min_distance : i].max()
+            and series.iloc[i] >= series.iloc[i + 1 : i + min_distance + 1].max()
+        ):
+            peaks.append(i)
+    return peaks
+
+
+def _find_troughs(series: pd.Series, min_distance: int = 10) -> list[int]:
+    """Find trough indices in a series."""
+    troughs = []
+    for i in range(min_distance, len(series) - min_distance):
+        if (
+            series.iloc[i] <= series.iloc[i - min_distance : i].min()
+            and series.iloc[i] <= series.iloc[i + 1 : i + min_distance + 1].min()
+        ):
+            troughs.append(i)
+    return troughs
+
+
+def _detect_head_and_shoulders(
+    close: pd.Series, high: pd.Series, low: pd.Series
+) -> bool:
+    """Detect head and shoulders pattern."""
+    if len(close) < 90:
+        return False
+
+    # Look for pattern: left shoulder, head (higher), right shoulder (lower than head)
+    highs = high.tail(90)
+
+    peaks = _find_peaks(highs, min_distance=15)
+    if len(peaks) < 3:
+        return False
+
+    # Get the three most recent peaks
+    if len(peaks) < 3:
+        return False
+
+    peak1 = highs.iloc[peaks[-3]] if len(peaks) >= 3 else 0
+    peak2 = highs.iloc[peaks[-2]]  # Head should be highest
+    peak3 = highs.iloc[peaks[-1]]
+
+    # Head should be highest, shoulders should be lower and roughly equal
+    if peak1 == 0 or peak2 == 0:
+        return False
+
+    head_higher = peak2 > peak1 and peak2 > peak3
+    shoulders_similar = abs(peak1 - peak3) / peak1 < 0.05  # Within 5%
+
+    return head_higher and shoulders_similar
+
+
+def _detect_inverted_head_and_shoulders(
+    close: pd.Series, high: pd.Series, low: pd.Series
+) -> bool:
+    """Detect inverted head and shoulders pattern."""
+    if len(close) < 90:
+        return False
+
+    lows = low.tail(90)
+
+    troughs = _find_troughs(lows, min_distance=15)
+    if len(troughs) < 3:
+        return False
+
+    trough1 = lows.iloc[troughs[-3]] if len(troughs) >= 3 else 0
+    trough2 = lows.iloc[troughs[-2]]  # Head should be lowest
+    trough3 = lows.iloc[troughs[-1]]
+
+    # Head should be lowest, shoulders should be higher and roughly equal
+    if trough1 == 0 or trough2 == 0:
+        return False
+
+    head_lower = trough2 < trough1 and trough2 < trough3
+    shoulders_similar = abs(trough1 - trough3) / trough1 < 0.05  # Within 5%
+
+    return head_lower and shoulders_similar
+
+
+def _detect_triangle(high: pd.Series, low: pd.Series, close: pd.Series) -> str | None:
+    """Detect triangle patterns (ascending, descending, or symmetrical)."""
+    if len(close) < 60:
+        return None
+
+    recent_highs = high.tail(60)
+    recent_lows = low.tail(60)
+
+    peaks = _find_peaks(recent_highs, min_distance=10)
+    troughs = _find_troughs(recent_lows, min_distance=10)
+
+    if len(peaks) < 2 or len(troughs) < 2:
+        return None
+
+    # Get slope of trendlines
+    peak_slope = (recent_highs.iloc[peaks[-1]] - recent_highs.iloc[peaks[0]]) / len(
+        peaks
+    )
+    trough_slope = (recent_lows.iloc[troughs[-1]] - recent_lows.iloc[troughs[0]]) / len(
+        troughs
+    )
+
+    # Ascending triangle: horizontal resistance, rising support
+    if peak_slope < 0.01 and trough_slope > 0:
+        return "ascending"
+    # Descending triangle: falling resistance, horizontal support
+    if peak_slope < 0 and trough_slope < 0.01:
+        return "descending"
+    # Symmetrical triangle: both converging
+    if abs(peak_slope) < 0.02 and abs(trough_slope) < 0.02:
+        return "symmetrical"
+
+    return None
+
+
+def _detect_flag(close: pd.Series, volume: pd.Series, threshold: float = 0.15) -> bool:
+    """Detect flag pattern (sharp move followed by consolidation with lower volume)."""
+    if len(close) < 20:
+        return False
+
+    recent = close.tail(20)
+    # Flag: sharp movement (>threshold %) followed by slight pullback
+    pct_change = (recent.iloc[-1] - recent.iloc[0]) / recent.iloc[0]
+
+    # Should have significant move up (5%+) followed by small consolidation
+    if pct_change < threshold:
+        return False
+
+    # Check volume decrease during consolidation
+    if len(volume) < 20:
+        return False
+
+    recent_volume = volume.tail(10)
+    earlier_volume = volume.tail(20).head(10)
+
+    if earlier_volume.mean() == 0:
+        return False
+
+    volume_decrease = recent_volume.mean() < earlier_volume.mean() * 0.7
+
+    return volume_decrease
+
+
+def _detect_cup_and_handle(close: pd.Series, min_cup_depth: float = 0.10) -> bool:
+    """Detect cup and handle pattern."""
+    if len(close) < 60:
+        return False
+
+    recent = close.tail(60)
+
+    # Look for U-shaped pattern (cup)
+    # The cup should be at least min_cup_depth % deep
+    max_price = recent.max()
+    min_price = recent.min()
+    cup_depth = (max_price - min_price) / max_price
+
+    if cup_depth < min_cup_depth:
+        return False
+
+    # For simplicity, check if there's a clear U shape by comparing start and end prices
+    start_price = recent.iloc[0]
+    end_price = recent.iloc[-1]
+
+    # Cup should be roughly U-shaped (start and end at similar levels)
+    price_diff = abs(start_price - end_price) / start_price
+    if price_diff > 0.10:  # More than 10% difference between start and end
+        return False
+
+    # Handle: slight downward drift after cup
+    last_10 = recent.tail(10)
+    handle_slope = (last_10.iloc[-1] - last_10.iloc[0]) / last_10.iloc[0]
+
+    # Handle should be slight downward (< 5%)
+    return -0.05 < handle_slope < 0

--- a/backend/services/analyzer.py
+++ b/backend/services/analyzer.py
@@ -69,12 +69,16 @@ class StockAnalyzer:
         start_date: str | None,
         end_date: str | None,
     ) -> Any:
-        """Return cached OHLC if fresh (< 5 min), otherwise fetch and cache."""
+        """Return cached OHLC if fresh (< 30 min), otherwise fetch and cache.
+
+        Using 30-min cache for OHLC data to reduce Yahoo Finance API calls.
+        Historical data doesn't change frequently, so 30-min staleness is acceptable.
+        """
         now = datetime.now()
-        cache_key = f"{ticker}"
+        cache_key = f"{ticker}_{period}_{start_date}_{end_date}"
         if cache_key in self._ohlc_cache:
             cached_time, cached = self._ohlc_cache[cache_key]
-            if now - cached_time < timedelta(minutes=5):
+            if now - cached_time < timedelta(minutes=30):
                 app_logger.debug(f"Reusing cached OHLC for {ticker}")
                 return cached
 
@@ -147,6 +151,8 @@ class StockAnalyzer:
         tech_indicators = technical_service.calculate_all(df)
         current_price = float(df["close"].iloc[-1]) if not df.empty else None
         advanced_metrics = advanced_service.calculate_all(df)
+
+        # News omitted to avoid extra Yahoo Finance API calls
 
         tech_summary = f"RSI: {tech_indicators.rsi_14}, MACD: {tech_indicators.macd}, SMA20: {tech_indicators.sma_20}, SMA50: {tech_indicators.sma_50}, SMA200: {tech_indicators.sma_200}, Price: {current_price:.2f}"
 
@@ -251,6 +257,46 @@ class StockAnalyzer:
                 if advanced_metrics.seasonal
                 else None,
             },
+            "patterns": {
+                "adx": advanced_metrics.patterns.adx
+                if advanced_metrics.patterns
+                else None,
+                "gap_up_detected": advanced_metrics.patterns.gap_up_detected
+                if advanced_metrics.patterns
+                else False,
+                "gap_down_detected": advanced_metrics.patterns.gap_down_detected
+                if advanced_metrics.patterns
+                else False,
+                "head_and_shoulders": advanced_metrics.patterns.head_and_shoulders
+                if advanced_metrics.patterns
+                else False,
+                "inverted_head_and_shoulders": advanced_metrics.patterns.inverted_head_and_shoulders
+                if advanced_metrics.patterns
+                else False,
+                "double_top": advanced_metrics.patterns.double_top
+                if advanced_metrics.patterns
+                else False,
+                "double_bottom": advanced_metrics.patterns.double_bottom
+                if advanced_metrics.patterns
+                else False,
+                "triangle_pattern": advanced_metrics.patterns.triangle_pattern
+                if advanced_metrics.patterns
+                else None,
+                "flag_pattern": advanced_metrics.patterns.flag_pattern
+                if advanced_metrics.patterns
+                else False,
+                "cup_and_handle": advanced_metrics.patterns.cup_and_handle
+                if advanced_metrics.patterns
+                else False,
+                "support_break": advanced_metrics.patterns.support_break
+                if advanced_metrics.patterns
+                else False,
+                "resistance_break": advanced_metrics.patterns.resistance_break
+                if advanced_metrics.patterns
+                else False,
+            }
+            if advanced_metrics.patterns
+            else None,
         }
 
         return ai_service.interpret(
@@ -258,7 +304,7 @@ class StockAnalyzer:
             company_name=ticker_info.company.name,
             technical_summary=tech_summary,
             fundamental_summary=fundamental_summary,
-            news_summary="News integration pending",
+            news_summary="News integration omitted to minimize API calls.",
             advanced_metrics=advanced_metrics_dict,
             additional_fundamentals=additional_fundamentals,
         )
@@ -285,7 +331,9 @@ def _parse_ticker_info(ticker: str, info: dict) -> TickerInfo:
         ),
         valuation=ValuationMetrics(
             market_cap=info.get("marketCap"),
-            pe_ratio=info.get("trailingPE"),
+            pe_ratio=info.get(
+                "trailingPE"
+            ),  # Already a ratio (e.g., 25.5), not a decimal
             forward_pe=info.get("forwardPE"),
             peg_ratio=info.get("pegRatio"),
             price_to_book=info.get("priceToBook"),
@@ -510,13 +558,27 @@ def _build_analysis_response(
             {"name": "SMA 50", "value": tech_indicators.sma_50, "unit": "$"},
             {"name": "SMA 100", "value": tech_indicators.sma_100, "unit": "$"},
             {"name": "SMA 200", "value": tech_indicators.sma_200, "unit": "$"},
+            {"name": "EMA 12", "value": tech_indicators.ema_12, "unit": "$"},
+            {"name": "EMA 26", "value": tech_indicators.ema_26, "unit": "$"},
+            {"name": "EMA 50", "value": tech_indicators.ema_50, "unit": "$"},
         ],
         "momentum": [
             {"name": "RSI 14", "value": tech_indicators.rsi_14, "unit": ""},
+            {"name": "RSI 21", "value": tech_indicators.rsi_21, "unit": ""},
             {"name": "MACD", "value": tech_indicators.macd, "unit": "$"},
+            {"name": "MACD Signal", "value": tech_indicators.macd_signal, "unit": "$"},
+            {
+                "name": "MACD Histogram",
+                "value": tech_indicators.macd_histogram,
+                "unit": "$",
+            },
+            {"name": "Stochastic %K", "value": tech_indicators.stoch_k, "unit": ""},
+            {"name": "Stochastic %D", "value": tech_indicators.stoch_d, "unit": ""},
+            {"name": "Williams %R", "value": tech_indicators.williams_r, "unit": ""},
         ],
         "volatility": [
             {"name": "ATR 14", "value": tech_indicators.atr_14, "unit": "$"},
+            {"name": "ATR 21", "value": tech_indicators.atr_21, "unit": "$"},
             {
                 "name": "Volatility 30D",
                 "value": tech_indicators.volatility_30d,
@@ -526,6 +588,26 @@ def _build_analysis_response(
                 "name": "Volatility 90D",
                 "value": tech_indicators.volatility_90d,
                 "unit": "%",
+            },
+            {
+                "name": "Volatility 365D",
+                "value": tech_indicators.volatility_365d,
+                "unit": "%",
+            },
+            {
+                "name": "Bollinger Upper",
+                "value": tech_indicators.bollinger_upper,
+                "unit": "$",
+            },
+            {
+                "name": "Bollinger Lower",
+                "value": tech_indicators.bollinger_lower,
+                "unit": "$",
+            },
+            {
+                "name": "Bollinger Width",
+                "value": tech_indicators.bollinger_width,
+                "unit": "$",
             },
         ],
     }

--- a/backend/services/technical.py
+++ b/backend/services/technical.py
@@ -128,12 +128,13 @@ def _to_float(val) -> float | None:
 
 
 def _calc_rsi(close: pd.Series, period: int = 14) -> float | None:
-    delta = close.diff()
-    gain = (delta.where(delta > 0, 0)).rolling(window=period).mean()
-    loss = (-delta.where(delta < 0, 0)).rolling(window=period).mean()
-    rs = gain / loss
-    rsi = 100 - (100 / (1 + rs))
-    return float(rsi.iloc[-1]) if len(rsi) > 0 else None
+    try:
+        from ta.momentum import RSIIndicator
+
+        rsi = RSIIndicator(close, window=period)
+        return float(rsi.rsi().iloc[-1]) if len(close) >= period else None
+    except Exception:
+        return None
 
 
 def _calc_macd(close: pd.Series) -> tuple[float | None, float | None, float | None]:

--- a/backend/sources/yahoo.py
+++ b/backend/sources/yahoo.py
@@ -2,6 +2,7 @@
 
 from asyncio import Semaphore
 from datetime import datetime, timedelta
+from typing import Callable, TypeVar
 
 import pandas as pd
 import yfinance as yf
@@ -12,6 +13,8 @@ from domain.models import OHLCData
 from domain.exceptions import TickerNotFoundError, RateLimitError
 from infrastructure.logging import app_logger
 
+T = TypeVar("T")
+
 # Module-level singleton: serializes all Yahoo Finance API calls across all
 # DataSource instances to prevent burst-triggered rate limits on cold starts.
 _yahoo_semaphore = Semaphore(1)
@@ -20,12 +23,11 @@ _yahoo_semaphore = Semaphore(1)
 _ticker_info_cache: dict[str, tuple[datetime, dict]] = {}
 
 
-async def _fetch_with_semaphore(func):
+async def _fetch_with_semaphore(func: Callable[[], T]) -> T:
     """Execute a Yahoo Finance fetch call with semaphore serialization.
 
-    The semaphore prevents burst traffic that could trigger Yahoo's rate limits.
-    On rate limit error, fails fast rather than retrying inside the semaphore
-    (which would block the single worker for many seconds during backoff).
+    The semaphore prevents burst traffic. Rate limit errors fail fast and bubble up
+    so the caller can handle gracefully (cached data or user-facing retry message).
     """
     async with _yahoo_semaphore:
         try:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { AnalysisResults } from './components/AnalysisResults';
 import { PerformanceCalculatorPage } from './pages/PerformanceCalculatorPage';
 import { WatchlistPage } from './pages/WatchlistPage';
 import { useState, useEffect } from 'react';
+import { Skeleton } from './components/shared/SkeletonLoader';
 import './App.css';
 import { PERIODS, getDateRange } from './constants';
 import { ErrorAlert } from './components/shared/ErrorAlert';
@@ -70,32 +71,22 @@ function AnalysisTab(
     errorAI,
     data,
     handleAnalyze,
-    updateChartData,
     handleGenerateAI,
   } = props;
   // Get date range for the selected period
   const dateRange = getDateRange(period);
 
-  // Handle period change from chart - lightweight chart-only update (no metrics recalculation)
-  const handleChartPeriodChange = (newPeriod: string) => {
-    setPeriod(newPeriod);
-    if (ticker.trim()) {
-      const newDateRange = getDateRange(newPeriod);
-      updateChartData(newDateRange);
-    }
-  };
-
   return (
-    <div className="max-w-6xl mx-auto px-6 py-12">
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
       {/* Search Section */}
-      <div className="mb-12">
-        <div className="flex flex-col sm:flex-row gap-4 mb-4">
+      <div className="mb-8 sm:mb-12">
+        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 mb-4">
           <div className="flex-1">
             <AutocompleteInput
               value={ticker}
               onChange={setTicker}
               onSubmit={() => handleAnalyze(undefined, dateRange)}
-              placeholder="Enter ticker (e.g., AAPL, CBA.AX for ASX, NVDA for NASDAQ)"
+              placeholder="Enter ticker (e.g., AAPL, CBA.AX, HSBA.L)"
               disabled={loading}
               submitLabel={loading ? 'Analyzing...' : 'Analyze'}
               showSubmitButton={true}
@@ -123,16 +114,70 @@ function AnalysisTab(
         {error && <ErrorAlert message={error} />}
       </div>
 
+      {/* Loading state */}
+      {loading && (
+        <div className="space-y-5">
+          {/* Company header skeleton */}
+          <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl rounded-2xl p-6 border border-gray-200/30 dark:border-gray-800/30 animate-fade-in">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex-1">
+                <Skeleton className="h-8 w-64 mb-2" />
+                <Skeleton className="h-4 w-24 mb-3" />
+                <div className="flex gap-4">
+                  <Skeleton className="h-3 w-20" />
+                  <Skeleton className="h-3 w-20" />
+                </div>
+              </div>
+              <div className="text-right">
+                <Skeleton className="h-10 w-32 mb-2" />
+                <Skeleton className="h-4 w-20" />
+              </div>
+            </div>
+          </div>
+          {/* Chart skeleton */}
+          <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl rounded-2xl p-6 border border-gray-200/30 dark:border-gray-800/30">
+            <Skeleton className="h-6 w-32 mb-4" />
+            <Skeleton className="h-72 w-full rounded-xl" />
+          </div>
+          {/* Metrics skeleton */}
+          <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl rounded-2xl p-6 border border-gray-200/30 dark:border-gray-800/30">
+            <Skeleton className="h-6 w-40 mb-4" />
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i}>
+                  <Skeleton className="h-3 w-16 mb-2" />
+                  <Skeleton className="h-6 w-20" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Analysis Results */}
-      {data && (
+      {data && !loading && (
         <AnalysisResults
           data={data}
           period={period}
-          onPeriodChange={handleChartPeriodChange}
           loadingAI={loadingAI}
           errorAI={errorAI}
           onGenerateAI={handleGenerateAI}
         />
+      )}
+
+      {/* Empty state - no data, not loading, no error */}
+      {!data && !loading && !error && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-800/60 flex items-center justify-center mb-4">
+            <TrendingUp className="w-8 h-8 text-gray-400 dark:text-gray-500" />
+          </div>
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            Enter a ticker to begin
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 max-w-xs">
+            Search for any publicly traded company using its stock ticker symbol.
+          </p>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/AnalysisResults/AdvancedMetricsSection.tsx
+++ b/frontend/src/components/AnalysisResults/AdvancedMetricsSection.tsx
@@ -218,7 +218,7 @@ export function AdvancedMetricsSection({
             </span>
           </div>
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-x-5 gap-y-7">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-x-5 gap-y-7">
           <div>
             <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
               1 Month
@@ -261,6 +261,28 @@ export function AdvancedMetricsSection({
               className={`text-2xl font-semibold tracking-tight ${getGainLossColor(technical.returns_1y ?? 0)}`}
             >
               {technical.returns_1y != null ? `${(technical.returns_1y * 100).toFixed(2)}%` : 'N/A'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+              3 Years
+              <MetricDefinition text="Total return over the last 3 years." />
+            </p>
+            <p
+              className={`text-2xl font-semibold tracking-tight ${getGainLossColor(technical.returns_3y ?? 0)}`}
+            >
+              {technical.returns_3y != null ? `${(technical.returns_3y * 100).toFixed(2)}%` : 'N/A'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+              5 Years
+              <MetricDefinition text="Total return over the last 5 years." />
+            </p>
+            <p
+              className={`text-2xl font-semibold tracking-tight ${getGainLossColor(technical.returns_5y ?? 0)}`}
+            >
+              {technical.returns_5y != null ? `${(technical.returns_5y * 100).toFixed(2)}%` : 'N/A'}
             </p>
           </div>
           <div>
@@ -308,6 +330,97 @@ export function AdvancedMetricsSection({
         </div>
         <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-800">
           <h5 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-4 tracking-wide uppercase text-xs">
+            CAGR (Compound Annual Growth Rate)
+          </h5>
+          <div className="grid grid-cols-3 gap-6">
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+                2Y CAGR
+                <MetricDefinition text="Compound Annual Growth Rate over 2 years." />
+              </p>
+              <p
+                className={`text-xl font-semibold tracking-tight ${getGainLossColor(technical.cagr_2y ?? 0)}`}
+              >
+                {technical.cagr_2y != null ? `${(technical.cagr_2y * 100).toFixed(2)}%` : 'N/A'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+                3Y CAGR
+                <MetricDefinition text="Compound Annual Growth Rate over 3 years." />
+              </p>
+              <p
+                className={`text-xl font-semibold tracking-tight ${getGainLossColor(technical.cagr_3y ?? 0)}`}
+              >
+                {technical.cagr_3y != null ? `${(technical.cagr_3y * 100).toFixed(2)}%` : 'N/A'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+                5Y CAGR
+                <MetricDefinition text="Compound Annual Growth Rate over 5 years." />
+              </p>
+              <p
+                className={`text-xl font-semibold tracking-tight ${getGainLossColor(technical.cagr_5y ?? 0)}`}
+              >
+                {technical.cagr_5y != null ? `${(technical.cagr_5y * 100).toFixed(2)}%` : 'N/A'}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-800">
+          <h5 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-4 tracking-wide uppercase text-xs">
+            Pivot Points
+          </h5>
+          <div className="grid grid-cols-2 gap-6">
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+                Resistance 1
+                <MetricDefinition text="First resistance level based on Fibonacci retracement (38.2%)." />
+              </p>
+              <p className="text-xl font-semibold tracking-tight text-red-500 dark:text-red-400">
+                {technical.pivot_resistance_1 != null
+                  ? `$${technical.pivot_resistance_1.toFixed(2)}`
+                  : 'N/A'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+                Resistance 2
+                <MetricDefinition text="Second resistance level based on Fibonacci retracement (61.8%)." />
+              </p>
+              <p className="text-xl font-semibold tracking-tight text-red-400 dark:text-red-500">
+                {technical.pivot_resistance_2 != null
+                  ? `$${technical.pivot_resistance_2.toFixed(2)}`
+                  : 'N/A'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+                Support 1
+                <MetricDefinition text="First support level based on Fibonacci retracement (38.2%)." />
+              </p>
+              <p className="text-xl font-semibold tracking-tight text-emerald-600 dark:text-emerald-400">
+                {technical.pivot_support_1 != null
+                  ? `$${technical.pivot_support_1.toFixed(2)}`
+                  : 'N/A'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+                Support 2
+                <MetricDefinition text="Second support level based on Fibonacci retracement (61.8%)." />
+              </p>
+              <p className="text-xl font-semibold tracking-tight text-emerald-500 dark:text-emerald-300">
+                {technical.pivot_support_2 != null
+                  ? `$${technical.pivot_support_2.toFixed(2)}`
+                  : 'N/A'}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-800">
+          <h5 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-4 tracking-wide uppercase text-xs">
             Volume Analysis
           </h5>
           <div className="grid grid-cols-2 gap-6">
@@ -346,6 +459,97 @@ export function AdvancedMetricsSection({
           </div>
         </div>
       </div>
+
+      {/* Pattern Signals */}
+      {data.advanced_metrics.patterns && (
+        <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl rounded-2xl p-8 border border-gray-200/30 dark:border-gray-800/30 animate-fade-in transition-all duration-300">
+          <div className="mb-6 flex items-center gap-2">
+            <h4 className="text-base font-semibold text-gray-900 dark:text-white tracking-tight">
+              Pattern Signals
+            </h4>
+            <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-medium text-purple-600 dark:text-purple-400 bg-purple-50/60 dark:bg-purple-900/30 rounded-full">
+              Calculated
+            </span>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-6">
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+                Trend Strength (ADX)
+                <MetricDefinition text="Average Directional Index. Measures trend strength: <20 = weak (no trend), 20-40 = moderate, >40 = strong trend. Higher = more directional movement." />
+              </p>
+              {data.advanced_metrics.patterns.adx != null ? (
+                <div className="flex items-baseline gap-2">
+                  <p className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">
+                    {data.advanced_metrics.patterns.adx.toFixed(1)}
+                  </p>
+                  <p className="text-xs text-gray-400 dark:text-gray-500">
+                    {data.advanced_metrics.patterns.adx < 20
+                      ? 'Weak'
+                      : data.advanced_metrics.patterns.adx < 40
+                        ? 'Moderate'
+                        : 'Strong'}
+                  </p>
+                </div>
+              ) : (
+                <p className="text-2xl font-semibold tracking-tight text-gray-400">N/A</p>
+              )}
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">Gap Up</p>
+              <p
+                className={`text-2xl font-semibold tracking-tight ${
+                  data.advanced_metrics.patterns.gap_up_detected
+                    ? 'text-emerald-600 dark:text-emerald-400'
+                    : 'text-gray-300 dark:text-gray-600'
+                }`}
+              >
+                {data.advanced_metrics.patterns.gap_up_detected ? '↑' : '—'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">Gap Down</p>
+              <p
+                className={`text-2xl font-semibold tracking-tight ${
+                  data.advanced_metrics.patterns.gap_down_detected
+                    ? 'text-red-500 dark:text-red-400'
+                    : 'text-gray-300 dark:text-gray-600'
+                }`}
+              >
+                {data.advanced_metrics.patterns.gap_down_detected ? '↓' : '—'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 flex items-center gap-1">
+                Trend Direction
+                <MetricDefinition text="Based on ADX. Shows if stock is in strong uptrend, moderate uptrend, weak/range-bound, or downtrend." />
+              </p>
+              {data.advanced_metrics.patterns.adx != null ? (
+                <p
+                  className={`text-xl font-semibold tracking-tight ${
+                    data.advanced_metrics.patterns.adx >= 40
+                      ? 'text-emerald-600 dark:text-emerald-400'
+                      : data.advanced_metrics.patterns.adx >= 25
+                        ? 'text-blue-600 dark:text-blue-400'
+                        : data.advanced_metrics.patterns.adx >= 20
+                          ? 'text-yellow-600 dark:text-yellow-400'
+                          : 'text-gray-500 dark:text-gray-400'
+                  }`}
+                >
+                  {data.advanced_metrics.patterns.adx >= 40
+                    ? 'Strong ↑'
+                    : data.advanced_metrics.patterns.adx >= 25
+                      ? 'Uptrend'
+                      : data.advanced_metrics.patterns.adx >= 20
+                        ? 'Weak →'
+                        : 'Range'}
+                </p>
+              ) : (
+                <p className="text-xl font-semibold tracking-tight text-gray-400">N/A</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Seasonal & Cyclical Patterns */}
       {seasonal && seasonal.monthly_returns && (

--- a/frontend/src/components/AnalysisResults/CompanyHeader.tsx
+++ b/frontend/src/components/AnalysisResults/CompanyHeader.tsx
@@ -1,36 +1,103 @@
 import { AnalysisData } from '../../types/analysis';
 import { getGainLossColor } from '../../utils/formatting';
+import { Download, ChevronDown } from 'lucide-react';
+import { useState, useRef, useEffect } from 'react';
+
+function isMarketOpen(): boolean {
+  const now = new Date();
+  const day = now.getDay();
+  // Market closed on weekends
+  if (day === 0 || day === 6) return false;
+
+  // Get US Eastern time
+  const etOffset = -5; // EST (or -4 for EDT)
+  const utc = now.getTime() + now.getTimezoneOffset() * 60000;
+  const etTime = new Date(utc + 3600000 * etOffset);
+  const hour = etTime.getHours();
+  const minute = etTime.getMinutes();
+
+  // Market hours: 9:30 AM - 4:00 PM ET
+  const marketOpen = hour > 9 || (hour === 9 && minute >= 30);
+  const marketClose = hour < 16;
+  return marketOpen && marketClose;
+}
+
+function formatDataRange(start_date: string | null, end_date: string | null): string {
+  if (!end_date) return 'Unknown';
+  const end = new Date(end_date);
+  const endStr = end.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  if (!start_date) return endStr;
+  const start = new Date(start_date);
+  const startStr = start.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return `${startStr} – ${endStr}`;
+}
 
 interface CompanyHeaderProps {
   data: AnalysisData;
 }
 
 export function CompanyHeader({ data }: CompanyHeaderProps) {
+  const [showExportMenu, setShowExportMenu] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const marketOpen = isMarketOpen();
+
+  // Close on click outside
+  useEffect(() => {
+    if (!showExportMenu) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setShowExportMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showExportMenu]);
+
   return (
     <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl rounded-2xl p-8 border border-gray-200/30 dark:border-gray-800/30 animate-fade-in transition-all duration-300">
       <div className="flex items-start justify-between gap-6">
-        <div>
-          <h2 className="text-3xl font-semibold tracking-tight text-gray-900 dark:text-white">
+        <div className="flex-1 min-w-0">
+          <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight text-gray-900 dark:text-white truncate">
             {data.company_name}
           </h2>
           <span className="text-sm text-gray-500 dark:text-gray-400 font-mono">{data.ticker}</span>
-          <div className="flex gap-4 mt-3 text-xs text-gray-500 dark:text-gray-400">
-            {data.sector && (
-              <div>
-                <span className="font-medium text-gray-600 dark:text-gray-300">Sector:</span>{' '}
-                {data.sector}
-              </div>
-            )}
-            {data.industry && (
-              <div>
-                <span className="font-medium text-gray-600 dark:text-gray-300">Industry:</span>{' '}
-                {data.industry}
-              </div>
-            )}
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 sm:mt-3">
+            <div className="flex gap-4 text-xs text-gray-500 dark:text-gray-400">
+              {data.sector && (
+                <div>
+                  <span className="font-medium text-gray-600 dark:text-gray-300">Sector:</span>{' '}
+                  {data.sector}
+                </div>
+              )}
+              {data.industry && (
+                <div>
+                  <span className="font-medium text-gray-600 dark:text-gray-300">Industry:</span>{' '}
+                  {data.industry}
+                </div>
+              )}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span
+                className={`w-2 h-2 rounded-full ${marketOpen ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400'}`}
+              />
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                {marketOpen ? 'Market Open' : 'Market Closed'}
+              </span>
+            </div>
           </div>
         </div>
-        <div className="text-right">
-          <p className="text-4xl font-semibold tracking-tight text-gray-900 dark:text-white">
+        <div className="text-right min-w-0">
+          <p className="text-2xl sm:text-3xl lg:text-4xl font-semibold tracking-tight text-gray-900 dark:text-white">
             ${data.current_price.toFixed(2)}
           </p>
           {data.currency && (
@@ -54,12 +121,94 @@ export function CompanyHeader({ data }: CompanyHeaderProps) {
               Market Cap: ${(data.market_cap / 1e9).toFixed(1)}B
             </p>
           )}
-          {data.data_start_date && data.data_end_date && (
-            <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
-              {new Date(data.data_start_date).toLocaleDateString()} —{' '}
-              {new Date(data.data_end_date).toLocaleDateString()}
-            </p>
-          )}
+          <div className="flex items-center justify-end gap-2 mt-2">
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              Data: {formatDataRange(data.data_start_date, data.data_end_date)}
+            </span>
+            <div className="relative" ref={menuRef}>
+              <button
+                onClick={() => setShowExportMenu((v) => !v)}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300 bg-white/60 dark:bg-gray-800/60 backdrop-blur-xl border border-gray-200/30 dark:border-gray-700/30 rounded-lg hover:bg-gray-100/60 dark:hover:bg-gray-700/60 transition-colors"
+              >
+                <Download className="w-3.5 h-3.5" />
+                Export
+                <ChevronDown className="w-3 h-3" />
+              </button>
+              {showExportMenu && (
+                <div className="absolute right-0 top-full mt-1 z-50 bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl border border-gray-200/30 dark:border-gray-700/30 rounded-lg shadow-lg py-1 min-w-[120px]">
+                  <button
+                    onClick={() => {
+                      setShowExportMenu(false);
+                      const exportData = {
+                        ticker: data.ticker,
+                        company_name: data.company_name,
+                        sector: data.sector,
+                        industry: data.industry,
+                        current_price: data.current_price,
+                        currency: data.currency,
+                        market_cap: data.market_cap,
+                        timestamp: data.timestamp,
+                        chart_data: data.chart_data,
+                        technical_overview: data.technical_overview,
+                        fundamental_overview: data.fundamental_overview,
+                        advanced_metrics: data.advanced_metrics,
+                      };
+                      const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+                        type: 'application/json',
+                      });
+                      const url = URL.createObjectURL(blob);
+                      const a = document.createElement('a');
+                      a.href = url;
+                      a.download = `${data.ticker}_analysis_${new Date().toISOString().split('T')[0]}.json`;
+                      a.click();
+                      URL.revokeObjectURL(url);
+                    }}
+                    className="w-full px-4 py-2 text-xs text-left text-gray-700 dark:text-gray-200 hover:bg-gray-100/60 dark:hover:bg-gray-700/60 transition-colors"
+                  >
+                    Export as JSON
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowExportMenu(false);
+                      const rows: string[] = ['Metric,Value'];
+                      rows.push(`Ticker,${data.ticker}`);
+                      rows.push(`Company Name,${data.company_name}`);
+                      rows.push(`Current Price,$${data.current_price}`);
+                      rows.push(`Market Cap,$${data.market_cap}`);
+                      if (data.technical_overview.moving_averages) {
+                        data.technical_overview.moving_averages.forEach((m) => {
+                          rows.push(`SMA ${m.name},${m.value}`);
+                        });
+                      }
+                      if (data.technical_overview.momentum) {
+                        data.technical_overview.momentum.forEach((m) => {
+                          rows.push(`Momentum ${m.name},${m.value}`);
+                        });
+                      }
+                      Object.entries(data.fundamental_overview).forEach(([category, metrics]) => {
+                        if (Array.isArray(metrics)) {
+                          metrics.forEach((m) => {
+                            rows.push(`${category}.${m.name},${m.value ?? 'N/A'}`);
+                          });
+                        }
+                      });
+                      const csv = rows.join('\n');
+                      const blob = new Blob([csv], { type: 'text/csv' });
+                      const url = URL.createObjectURL(blob);
+                      const a = document.createElement('a');
+                      a.href = url;
+                      a.download = `${data.ticker}_analysis_${new Date().toISOString().split('T')[0]}.csv`;
+                      a.click();
+                      URL.revokeObjectURL(url);
+                    }}
+                    className="w-full px-4 py-2 text-xs text-left text-gray-700 dark:text-gray-200 hover:bg-gray-100/60 dark:hover:bg-gray-700/60 transition-colors"
+                  >
+                    Export as CSV
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/AnalysisResults/index.tsx
+++ b/frontend/src/components/AnalysisResults/index.tsx
@@ -10,7 +10,6 @@ import { AdvancedMetricsSection } from './AdvancedMetricsSection';
 interface AnalysisResultsProps {
   data: AnalysisData;
   period: string;
-  onPeriodChange: (period: string) => void;
   loadingAI?: boolean;
   errorAI?: string;
   onGenerateAI?: () => void;
@@ -19,7 +18,6 @@ interface AnalysisResultsProps {
 export function AnalysisResults({
   data,
   period,
-  onPeriodChange,
   loadingAI = false,
   errorAI,
   onGenerateAI,
@@ -38,7 +36,6 @@ export function AnalysisResults({
         currentPrice={data.current_price}
         chartData={data.chart_data}
         period={period}
-        onPeriodChange={onPeriodChange}
       />
 
       {/* Technical Overview */}

--- a/frontend/src/components/AutocompleteInput/index.tsx
+++ b/frontend/src/components/AutocompleteInput/index.tsx
@@ -17,7 +17,7 @@ export function AutocompleteInput({
   value,
   onChange,
   onSubmit,
-  placeholder = 'Enter stock ticker (e.g., AAPL, BHP.AX) in accordance with Yahoo Finance format',
+  placeholder = 'Enter ticker (e.g., AAPL, CBA.AX, HSBA.L)',
   disabled = false,
   submitLabel = 'Analyse',
   showSubmitButton = true,
@@ -31,6 +31,17 @@ export function AutocompleteInput({
 
   // Compute suggestions directly from value (derived state)
   const suggestions = value.trim() ? getFilteredTickers(value) : [];
+
+  // Get suffix hint for display
+  const getSuffixHint = (ticker: string): string | null => {
+    if (ticker.endsWith('.AX')) return 'Australia';
+    if (ticker.endsWith('.L')) return 'London';
+    if (ticker.endsWith('.TO')) return 'Toronto';
+    if (ticker.endsWith('.SS') || ticker.endsWith('.SZ')) return 'Shanghai';
+    if (ticker.endsWith('.HK')) return 'Hong Kong';
+    if (ticker.endsWith('.T')) return 'Tokyo';
+    return null;
+  };
 
   // Handle input change
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -167,21 +178,31 @@ export function AutocompleteInput({
           role="listbox"
           className="absolute z-50 w-full mt-1 bg-white/80 dark:bg-gray-900/90 backdrop-blur-xl border border-gray-200/30 dark:border-gray-800/30 rounded-lg shadow-lg max-h-60 overflow-y-auto"
         >
-          {suggestions.map((suggestion, index) => (
-            <li
-              key={suggestion}
-              role="option"
-              aria-selected={index === highlightedIndex}
-              className={`px-4 py-3 cursor-pointer transition-colors border-b border-gray-100 dark:border-gray-800 last:border-b-0 ${
-                index === highlightedIndex
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-white/80 dark:bg-gray-900/80 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800'
-              }`}
-              onClick={() => handleSuggestionClick(suggestion)}
-            >
-              <span className="font-medium">{suggestion}</span>
-            </li>
-          ))}
+          {suggestions.map((suggestion, index) => {
+            const suffixHint = getSuffixHint(suggestion);
+            return (
+              <li
+                key={suggestion}
+                role="option"
+                aria-selected={index === highlightedIndex}
+                className={`px-4 py-3 cursor-pointer transition-colors border-b border-gray-100 dark:border-gray-800 last:border-b-0 ${
+                  index === highlightedIndex
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white/80 dark:bg-gray-900/80 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800'
+                }`}
+                onClick={() => handleSuggestionClick(suggestion)}
+              >
+                <span className="font-medium">{suggestion}</span>
+                {suffixHint && (
+                  <span
+                    className={`ml-2 text-xs ${index === highlightedIndex ? 'text-blue-200' : 'text-gray-500 dark:text-gray-400'}`}
+                  >
+                    ({suffixHint})
+                  </span>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/frontend/src/components/PriceChart/index.tsx
+++ b/frontend/src/components/PriceChart/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, memo, useCallback } from 'react';
+import { useState, useMemo, memo } from 'react';
 import {
   LineChart,
   Line,
@@ -8,8 +8,32 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from 'recharts';
-import { PERIODS } from '../../constants';
+import { getChartPeriods } from '../../constants';
 import { getGainLossColor } from '../../utils/formatting';
+
+function _getCutoffDate(chartPeriod: string, lastDate: Date): Date | null {
+  if (chartPeriod === 'max') return null;
+  if (chartPeriod === 'ytd') return new Date(lastDate.getFullYear(), 0, 1);
+
+  const offsets: Record<string, [number, number]> = {
+    '1mo': [1, 0],
+    '3mo': [3, 0],
+    '6mo': [6, 0],
+    '1y': [0, 1],
+    '2y': [0, 2],
+    '5y': [0, 5],
+    '10y': [0, 10],
+  };
+
+  const offset = offsets[chartPeriod];
+  if (!offset) return null;
+
+  const [months, years] = offset;
+  const cutoff = new Date(lastDate);
+  if (months > 0) cutoff.setMonth(cutoff.getMonth() - months);
+  if (years > 0) cutoff.setFullYear(cutoff.getFullYear() - years);
+  return cutoff;
+}
 
 interface PriceChartProps {
   ticker: string;
@@ -22,7 +46,6 @@ interface PriceChartProps {
     sma200?: number | null;
   }[];
   period: string;
-  onPeriodChange: (period: string) => void;
 }
 
 export const PriceChart = memo(function PriceChart({
@@ -30,25 +53,41 @@ export const PriceChart = memo(function PriceChart({
   currentPrice,
   chartData,
   period,
-  onPeriodChange,
 }: PriceChartProps) {
-  const [selectedPeriod, setSelectedPeriod] = useState(period);
+  const [chartPeriod, setChartPeriod] = useState(() => {
+    const available = getChartPeriods(period);
+    return available.find((p) => p.value === period)?.value ?? available[0]?.value ?? '5y';
+  });
   const [showSMA20, setShowSMA20] = useState(false);
   const [showSMA50, setShowSMA50] = useState(false);
   const [showSMA200, setShowSMA200] = useState(false);
 
+  const availableChartPeriods = useMemo(() => getChartPeriods(period), [period]);
+
+  // Sync chart period when period changes (zoom out not allowed — only equal or lower)
+  const effectiveChartPeriod = useMemo(() => {
+    const available = getChartPeriods(period);
+    return available.some((p) => p.value === chartPeriod)
+      ? chartPeriod
+      : (available[0]?.value ?? '5y');
+  }, [period, chartPeriod]);
+
+  // Filter chart data based on selected chart period (zoom in only — no extra API calls)
+  const filteredData = useMemo(() => {
+    if (!chartData.length) return [];
+    const lastDate = new Date(chartData[chartData.length - 1].date);
+    const cutoff = _getCutoffDate(chartPeriod, lastDate);
+    if (!cutoff) return chartData;
+    return chartData.filter((d) => new Date(d.date) >= cutoff);
+  }, [chartData, chartPeriod]);
+
   // Check if SMA data is available
-  const hasSMAData = chartData.some(
+  const hasSMAData = filteredData.some(
     (point) => point.sma20 !== null || point.sma50 !== null || point.sma200 !== null,
   );
 
-  // Sync with parent period when it changes
-  useEffect(() => {
-    setSelectedPeriod(period);
-  }, [period]);
-
   // Transform chart data for the chart
-  const data = chartData.map((point) => ({
+  const data = filteredData.map((point) => ({
     date: new Date(point.date).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
@@ -65,17 +104,10 @@ export const PriceChart = memo(function PriceChart({
   const priceChange = latestPrice - startPrice;
   const percentChange = startPrice > 0 ? (priceChange / startPrice) * 100 : 0;
 
-  const handlePeriodChange = useCallback(
-    (newPeriod: string) => {
-      setSelectedPeriod(newPeriod);
-      onPeriodChange(newPeriod);
-    },
-    [onPeriodChange],
-  );
-
   return (
-    <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl rounded-2xl p-6 border border-gray-200/30 dark:border-gray-800/30 animate-fade-in transition-all duration-300">
-      <div className="flex items-center justify-between mb-5">
+    <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl rounded-2xl p-4 sm:p-6 border border-gray-200/30 dark:border-gray-800/30 animate-fade-in transition-all duration-300">
+      {/* Header - stack on mobile */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-4 sm:mb-5">
         <div>
           <h3 className="text-base font-semibold text-gray-900 dark:text-white">Price Chart</h3>
           <p className="text-sm text-gray-400 dark:text-gray-500 font-mono">
@@ -83,7 +115,7 @@ export const PriceChart = memo(function PriceChart({
           </p>
         </div>
         <div className="text-right">
-          <p className={`text-lg font-semibold ${getGainLossColor(priceChange)}`}>
+          <p className={`text-base sm:text-lg font-semibold ${getGainLossColor(priceChange)}`}>
             {priceChange >= 0 ? '+' : ''}
             {priceChange.toFixed(2)} ({percentChange.toFixed(2)}%)
           </p>
@@ -127,22 +159,25 @@ export const PriceChart = memo(function PriceChart({
         </div>
       )}
 
-      {/* Period Selector - horizontal scroll on mobile */}
+      {/* Chart Period Selector — only allows zooming in, no extra API calls */}
       <div className="overflow-x-auto hide-scrollbar mb-6 border-b border-gray-100 dark:border-gray-700">
         <div className="flex gap-1 min-w-max px-1">
-          {PERIODS.map((p) => (
-            <button
-              key={p.value}
-              onClick={() => handlePeriodChange(p.value)}
-              className={`px-4 py-2.5 text-xs font-medium transition-all duration-200 ${
-                selectedPeriod === p.value
-                  ? 'text-gray-900 dark:text-white border-b-2 border-gray-900 dark:border-gray-100'
-                  : 'text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300'
-              }`}
-            >
-              {p.label}
-            </button>
-          ))}
+          {availableChartPeriods.map((p) => {
+            const isActive = p.value === effectiveChartPeriod;
+            return (
+              <button
+                key={p.value}
+                onClick={() => setChartPeriod(p.value)}
+                className={`px-4 py-2.5 text-xs font-medium transition-all duration-200 ${
+                  isActive
+                    ? 'text-gray-900 dark:text-white border-b-2 border-gray-900 dark:border-gray-100'
+                    : 'text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300'
+                }`}
+              >
+                {p.label}
+              </button>
+            );
+          })}
         </div>
       </div>
 
@@ -169,11 +204,11 @@ export const PriceChart = memo(function PriceChart({
               axisLine={false}
               domain={['auto', 'auto']}
               tickFormatter={(value) => `$${value.toFixed(0)}`}
-              width={60}
+              width={52}
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: '#fff',
+                backgroundColor: 'rgba(255,255,255,0.95)',
                 border: '1px solid #e5e7eb',
                 borderRadius: '8px',
                 boxShadow: '0 2px 8px rgba(0,0,0,0.1)',

--- a/frontend/src/components/StockNews/index.tsx
+++ b/frontend/src/components/StockNews/index.tsx
@@ -31,18 +31,40 @@ export function StockNews({ ticker }: StockNewsProps) {
 
   if (loading) {
     return (
-      <div className="bg-white border border-gray-200 rounded-lg p-4">
-        <h3 className="text-sm font-semibold text-gray-900 mb-3">Latest News</h3>
-        <p className="text-xs text-gray-500">Loading...</p>
+      <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl rounded-2xl p-6 border border-gray-200/30 dark:border-gray-800/30">
+        <div className="mb-4">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Latest News</h3>
+        </div>
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="animate-pulse flex gap-3 p-3 rounded-xl bg-gray-100/60 dark:bg-gray-800/40"
+            >
+              <div className="w-16 h-16 bg-gray-200 dark:bg-gray-700 rounded-lg" />
+              <div className="flex-1">
+                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-2" />
+                <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     );
   }
 
   if (articles.length === 0) {
     return (
-      <div className="bg-white border border-gray-200 rounded-lg p-4">
-        <h3 className="text-sm font-semibold text-gray-900 mb-3">Latest News</h3>
-        <p className="text-xs text-gray-500">No news available</p>
+      <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl rounded-2xl p-6 border border-gray-200/30 dark:border-gray-800/30">
+        <div className="flex items-center gap-2 mb-4">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Latest News</h3>
+          <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-medium text-blue-600 dark:text-blue-400 bg-blue-50/60 dark:bg-blue-900/30 rounded-full">
+            Y! Finance
+          </span>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-4">
+          No news available for {ticker}
+        </p>
       </div>
     );
   }
@@ -68,51 +90,58 @@ export function StockNews({ ticker }: StockNewsProps) {
   const displayedArticles = showAll ? articles : articles.slice(0, INITIAL_COUNT);
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4">
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-semibold text-gray-900">Latest News</h3>
+    <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl rounded-2xl p-6 border border-gray-200/30 dark:border-gray-800/30">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Latest News</h3>
+          <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-medium text-blue-600 dark:text-blue-400 bg-blue-50/60 dark:bg-blue-900/30 rounded-full">
+            Y! Finance
+          </span>
+        </div>
         {articles.length > INITIAL_COUNT && (
           <button
             onClick={() => setShowAll(!showAll)}
-            className="text-xs text-blue-600 hover:text-blue-700 font-medium"
+            className="text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium"
           >
             {showAll ? 'Show less' : `Show all (${articles.length})`}
           </button>
         )}
       </div>
-      <div className="flex gap-3 overflow-x-auto pb-2">
+      <div className="space-y-3">
         {displayedArticles.map((article, index) => (
           <a
             key={index}
             href={article.link || '#'}
             target="_blank"
             rel="noopener noreferrer"
-            className="group flex-shrink-0 w-48"
+            className="flex gap-3 p-3 rounded-xl bg-gray-50/60 dark:bg-gray-800/40 hover:bg-gray-100/80 dark:hover:bg-gray-700/50 transition-colors"
           >
             {article.thumbnail && (
-              <div className="mb-2">
-                <img
-                  src={article.thumbnail}
-                  alt=""
-                  className="w-full h-20 object-cover rounded"
-                  onError={(e) => {
-                    (e.target as HTMLImageElement).style.display = 'none';
-                  }}
-                />
-              </div>
+              <img
+                src={article.thumbnail}
+                alt=""
+                className="w-16 h-16 object-cover rounded-lg flex-shrink-0"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = 'none';
+                }}
+              />
             )}
-            <h4 className="text-xs font-medium text-gray-900 group-hover:text-blue-600 line-clamp-2 leading-snug">
-              {article.title}
-            </h4>
-            <div className="flex items-center gap-2 mt-1">
-              {article.provider && (
-                <span className="text-xs text-gray-500 truncate">{article.provider}</span>
-              )}
-              {article.pub_date && (
-                <span className="text-xs text-gray-400 flex-shrink-0">
-                  {formatRelativeTime(article.pub_date)}
-                </span>
-              )}
+            <div className="flex-1 min-w-0">
+              <h4 className="text-sm font-medium text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 line-clamp-2 leading-snug">
+                {article.title}
+              </h4>
+              <div className="flex items-center gap-2 mt-1">
+                {article.provider && (
+                  <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                    {article.provider}
+                  </span>
+                )}
+                {article.pub_date && (
+                  <span className="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0">
+                    {formatRelativeTime(article.pub_date)}
+                  </span>
+                )}
+              </div>
             </div>
           </a>
         ))}

--- a/frontend/src/components/shared/ErrorAlert.tsx
+++ b/frontend/src/components/shared/ErrorAlert.tsx
@@ -1,17 +1,40 @@
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, Wifi, Search } from 'lucide-react';
 
 interface ErrorAlertProps {
   message: string;
   className?: string;
 }
 
+function inferType(message: string): 'error' | 'rate_limit' | 'not_found' {
+  if (message.includes('rate limit') || message.includes('Rate limit')) return 'rate_limit';
+  if (message.includes('No data found') || message.includes('not found')) return 'not_found';
+  return 'error';
+}
+
+const ICONS = {
+  error: AlertCircle,
+  rate_limit: Wifi,
+  not_found: Search,
+};
+
+const STYLES = {
+  error:
+    'bg-red-50/60 dark:bg-red-900/30 border-red-200/50 dark:border-red-800/50 text-red-800 dark:text-red-200',
+  rate_limit:
+    'bg-amber-50/60 dark:bg-amber-900/30 border-amber-200/50 dark:border-amber-800/50 text-amber-800 dark:text-amber-200',
+  not_found:
+    'bg-blue-50/60 dark:bg-blue-900/30 border-blue-200/50 dark:border-blue-800/50 text-blue-800 dark:text-blue-200',
+};
+
 export function ErrorAlert({ message, className = '' }: ErrorAlertProps) {
+  const type = inferType(message);
+  const Icon = ICONS[type];
+  const style = STYLES[type];
+
   return (
-    <div
-      className={`mt-4 p-4 bg-red-50/60 dark:bg-red-900/30 border border-red-200/50 dark:border-red-800/50 rounded-xl flex gap-3 ${className}`}
-    >
-      <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
-      <p className="text-red-800 dark:text-red-200 text-sm">{message}</p>
+    <div className={`mt-4 p-4 rounded-xl border flex gap-3 ${style} ${className}`}>
+      <Icon className="w-5 h-5 flex-shrink-0 mt-0.5" />
+      <p className="text-sm leading-relaxed">{message}</p>
     </div>
   );
 }

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -5,16 +5,24 @@ export const ERROR_MESSAGES = {
 } as const;
 
 export const PERIODS = [
-  { value: '1mo', label: '1M' },
-  { value: '3mo', label: '3M' },
-  { value: '6mo', label: '6M' },
-  { value: '1y', label: '1Y' },
-  { value: '2y', label: '2Y' },
-  { value: '5y', label: '5Y' },
-  { value: '10y', label: '10Y' },
-  { value: 'ytd', label: 'YTD' },
-  { value: 'max', label: 'Max' },
+  { value: '1mo', label: '1M', order: 1 },
+  { value: '3mo', label: '3M', order: 2 },
+  { value: '6mo', label: '6M', order: 3 },
+  { value: '1y', label: '1Y', order: 4 },
+  { value: '2y', label: '2Y', order: 5 },
+  { value: '5y', label: '5Y', order: 6 },
+  { value: '10y', label: '10Y', order: 7 },
+  { value: 'ytd', label: 'YTD', order: 99 }, // special — always available
+  { value: 'max', label: 'Max', order: 8 },
 ];
+
+// Returns periods the chart can show given the analysis period.
+// Chart can only zoom in (lower order), not zoom out beyond what was fetched.
+export const getChartPeriods = (analysisPeriod: string): typeof PERIODS => {
+  const analysis = PERIODS.find((p) => p.value === analysisPeriod);
+  if (!analysis) return PERIODS;
+  return PERIODS.filter((p) => p.order <= analysis.order || p.value === 'ytd');
+};
 
 // Extended PERIODS with date calculation properties
 const PERIODS_WITH_CALC = [

--- a/frontend/src/constants/metrics.ts
+++ b/frontend/src/constants/metrics.ts
@@ -7,20 +7,48 @@ export const movingAverageDefinitions: Record<string, string> = {
     'Simple Moving Average over the last 100 trading days (in price units). Medium-long term trend indicator.',
   'SMA 200':
     'Simple Moving Average over the last 200 trading days (in price units). Long-term trend indicator. Price above 200 SMA = long-term bullish.',
+  'EMA 12':
+    'Exponential Moving Average with 12-period span. More responsive to recent prices than SMA. Short-term trend indicator.',
+  'EMA 26':
+    'Exponential Moving Average with 26-period span. Used in MACD calculation. Medium-term trend indicator.',
+  'EMA 50':
+    'Exponential Moving Average with 50-period span. Medium-term trend with more weight on recent prices.',
 };
 
 export const momentumDefinitions: Record<string, string> = {
   'RSI 14':
     'Relative Strength Index over 14 periods (scale 0-100). >70 = overbought (possible pullback), <30 = oversold (possible bounce). Below 50 = bearish, above 50 = bullish.',
+  'RSI 21':
+    'Relative Strength Index over 21 periods (scale 0-100). More smoothed than RSI 14. >70 = overbought, <30 = oversold.',
   MACD: 'Moving Average Convergence Divergence (in price units, e.g., +2.50 means short-term MA is $2.50 above long-term MA). Positive MACD = bullish momentum.',
+  'MACD Signal':
+    'Signal line for MACD (9-period EMA of MACD). When MACD crosses above signal = bullish, below = bearish.',
+  'MACD Histogram':
+    'MACD minus Signal line. Positive = histogram rising (bullish), negative = histogram falling (bearish).',
+  'Stochastic %K':
+    'Stochastic oscillator %K (14-period). Measures close position relative to high-low range. >80 = overbought, <20 = oversold.',
+  'Stochastic %D':
+    'Stochastic oscillator %D (3-period SMA of %K). More smoothed, used with %K for signals.',
+  'Williams %R':
+    'Williams %R over 14 periods (scale -100 to 0). >-20 = overbought, <-80 = oversold. Similar to RSI but inverted.',
 };
 
 export const volatilityDefinitions: Record<string, string> = {
   'ATR 14':
     'Average True Range over 14 periods (in price units, e.g., $3.59 means the stock moves ~$3.59 per day on average). Higher ATR = more volatile stock.',
+  'ATR 21':
+    'Average True Range over 21 periods. More smoothed volatility measure. Higher = more volatile.',
   'Volatility 30D':
     '30-day annualized volatility (shown as percentage, e.g., 17% means the stock has historically fluctuated 17% annually). Higher = more volatile.',
   'Volatility 90D': '90-day annualized volatility (shown as percentage). Higher = more volatile.',
+  'Volatility 365D':
+    '365-day annualized volatility (shown as percentage). Long-term volatility view. Higher = more volatile.',
+  'Bollinger Upper':
+    'Upper Bollinger Band (20 SMA + 2 std dev). Price near upper band may indicate overbought conditions.',
+  'Bollinger Lower':
+    'Lower Bollinger Band (20 SMA - 2 std dev). Price near lower band may indicate oversold conditions.',
+  'Bollinger Width':
+    'Difference between upper and lower Bollinger Bands. Higher = more volatile market, lower = less volatile.',
 };
 
 export const profitabilityDefinitions: Record<string, string> = {

--- a/frontend/src/hooks/useStockAnalysis.ts
+++ b/frontend/src/hooks/useStockAnalysis.ts
@@ -74,11 +74,26 @@ export const useStockAnalysis = (): UseStockAnalysisReturn => {
         queryClient.setQueryData([ANALYSIS_KEY, ticker, period], result);
       } catch (err: unknown) {
         if (err && typeof err === 'object' && 'response' in err) {
-          const axiosError = err as { response?: { data?: { detail?: string }; status?: number } };
+          const axiosError = err as {
+            response?: {
+              data?: { detail?: string };
+              status?: number;
+              headers?: { [key: string]: string };
+            };
+          };
           const status = axiosError.response?.status;
           const detail = axiosError.response?.data?.detail;
+          const retryAfter = axiosError.response?.headers?.['retry-after'];
 
-          if (status === 404) {
+          // Detect rate limit errors (503 or RATE_LIMIT_MSG detail)
+          const isRateLimit = status === 503 || detail === 'RATE_LIMIT_MSG';
+
+          if (isRateLimit) {
+            const retrySeconds = retryAfter ? parseInt(retryAfter, 10) : 60;
+            setError(
+              `Yahoo Finance rate limit exceeded. Please wait ${retrySeconds} seconds before trying again.`,
+            );
+          } else if (status === 404) {
             setError(
               `No data found for "${ticker.toUpperCase()}". Please check the ticker and try again.`,
             );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,13 +42,18 @@ body::before {
 /* Dark mode using .dark class */
 .dark body::before {
   background:
-    radial-gradient(ellipse 80% 60% at 50% -20%, rgba(99, 102, 241, 0.1) 0%, transparent 50%),
-    radial-gradient(ellipse 60% 40% at 80% 100%, rgba(59, 130, 246, 0.06) 0%, transparent 50%),
-    radial-gradient(ellipse 50% 30% at 20% 80%, rgba(139, 92, 246, 0.05) 0%, transparent 50%);
+    radial-gradient(ellipse 80% 60% at 50% -20%, rgba(99, 102, 241, 0.12) 0%, transparent 50%),
+    radial-gradient(ellipse 60% 40% at 80% 100%, rgba(59, 130, 246, 0.08) 0%, transparent 50%),
+    radial-gradient(ellipse 50% 30% at 20% 80%, rgba(139, 92, 246, 0.06) 0%, transparent 50%);
 }
 
 .dark {
   color-scheme: dark;
+}
+
+/* Ensure sufficient contrast in dark mode */
+.dark body {
+  @apply bg-gray-950 text-gray-100;
 }
 
 /* Selection styling */
@@ -62,8 +67,8 @@ body::before {
 
 /* Custom scrollbar */
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {

--- a/frontend/src/types/analysis.ts
+++ b/frontend/src/types/analysis.ts
@@ -177,7 +177,7 @@ export interface AnalysisData {
       inverted_head_and_shoulders: boolean;
       double_top: boolean;
       double_bottom: boolean;
-      triangle_pattern: boolean;
+      triangle_pattern: string | null;
       flag_pattern: boolean;
       cup_and_handle: boolean;
       adx: number | null;


### PR DESCRIPTION
## Summary
- **Rate limit handling**: Remove exponential backoff retry; use fail-fast with semaphore serialization to reduce API pressure
- **News API removal**: Remove Yahoo Finance news endpoint and news API calls to minimize rate limit risk
- **Chart period filter**: Fix period mismatch - chart period selector only allows equal or lower period (zoom in only, no extra API calls)
- **Export button UX**: Fix export buttons positioned over stock price - moved to dropdown inline with data freshness label
- **Data freshness display**: Show date range instead of single date in "Data:" label
- **Linting fixes**: ESLint cascading render error (useEffect+setState → useMemo), ruff F841 (unused variable), syntax error in getChartPeriods

## Test plan
- [x] Analyze a ticker with 5Y period, then select 10Y on chart - should stay at 5Y (zoom out blocked)
- [x] Analyze a ticker with 10Y period, then select any lower period on chart - should work fine
- [x] Check export dropdown appears inline with data freshness label
- [x] Verify Data label shows date range (e.g., "Apr 10, 2023 – Apr 10, 2026")
- [x] Verify news placeholder is shown (no news API calls)
- [x] Run `uv run --directory backend ruff check .` - no errors
- [x] Run `npx --prefix frontend eslint .` - no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)